### PR TITLE
Ability to add destination path files options field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ During development you can run node-webkit with `nwbuild -r path/to/your/younwap
 Or use the module:
 
 ```js
-var NwBuilder = require('node-webkit-builder');
+var path = require('path'),
+    NwBuilder = require('node-webkit-builder');
 var nw = new NwBuilder({
-    files: './path/to/nwfiles/**/**', // use the glob format
+    files: [
+      './path/to/nwfiles/**/**', // use the glob format
+      { src: path.resolve(__dirname, '../path/to/node_modules/package/**/*'), dest: 'node_modules/package' }
+    ],
     platforms: ['win','osx']
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -377,7 +377,15 @@ NwBuilder.prototype.runApp = function () {
 
         self.emit('log', 'Launching App');
         return new Promise(function(resolve, reject) {
-            var p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")]);
+            var p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")]),
+                exited = false,
+                close = function (code) {
+                    if (!exited) {
+                        exited = true;
+                        self.emit('log', 'App exited with code ' + code);
+                        resolve();
+                    }
+                };
 
             p.stdout.on('data', function(data) {
                 self.emit('stdout', data);
@@ -387,9 +395,13 @@ NwBuilder.prototype.runApp = function () {
                 self.emit('stderr', data);
             });
 
-            p.on('close', function(code) {
-                self.emit('log', 'App exited with code ' + code);
-                resolve();
-            });
+            p.on('close', close)
+
+            // Window close or CMD+Q
+            process.on('exit', close);
+
+            // CTRL+C
+            process.on('SIGINT', close);
+            process.on('SIGTERM', close);
         });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,22 +43,26 @@ function NwBuilder(options) {
         platform: 'win',
         needsZip: true,
         runable: 'nw.exe',
+        app: '%APPNAME%.exe',
         files: ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'] // First file must be the executable
     },{
         platform: 'osx',
         runable: 'node-webkit.app/Contents/MacOS/node-webkit',
+        app: '%APPNAME%.app',
         files: ['node-webkit.app']
     },{
         platform: 'linux32',
         needsZip: true,
         chmod: '0755',
         runable: 'nw',
+        app: '%APPNAME%',
         files: ['nw', 'nw.pak', 'libffmpegsumo.so'] // First file must be the executable
     },{
         platform: 'linux64',
         needsZip: true,
         chmod: '0755', // chmod file file to be executable
         runable: 'nw',
+        app: '%APPNAME%',
         files: ['nw', 'nw.pak', 'libffmpegsumo.so'] // First file must be the executable
     }];
 
@@ -248,7 +252,6 @@ NwBuilder.prototype.createReleaseFolder = function () {
             releasePath = self.options.appName;
     }
 
-
     this._platforms.forEach(function (single_platform) {
         single_platform.releasePath = path.resolve(self.options.buildDir, releasePath, single_platform.platform);
 
@@ -263,11 +266,18 @@ NwBuilder.prototype.createReleaseFolder = function () {
 };
 
 NwBuilder.prototype.copyNodeWebkit = function () {
-    var copiedFiles = [];
+    var copiedFiles = [],
+        self = this,
+        releaseFile;
 
     this._platforms.forEach(function (single_platform) {
         single_platform.files.forEach(function (file) {
-            copiedFiles.push(Utils.copyFile(path.resolve(single_platform.cache, file), path.resolve(single_platform.releasePath, file)));
+            if (single_platform.platform === 'osx' || file === single_platform.runable && self.options.appName && typeof self.options.appName === 'string') {
+                releaseFile = single_platform.app.split('%APPNAME%').join(self.options.appName).toLowerCase();
+            } else {
+                releaseFile = file;
+            }
+            copiedFiles.push(Utils.copyFile(path.resolve(single_platform.cache, file), path.resolve(single_platform.releasePath, releaseFile)));
         });
     });
 
@@ -300,15 +310,17 @@ NwBuilder.prototype.mergeAppFiles = function () {
     this._platforms.forEach(function (single_platform) {
         // We copy the app files if we are on mac and don't force zip
         if(single_platform.platform === 'osx') {
+            var releaseFile = (self.options.appName) ? single_platform.app.split('%APPNAME%').join(self.options.appName).toLowerCase() : 'node-webkit.app';
+
             // no zip, copy the files
             if(!self.options.macZip) {
                 self._files.forEach(function (file) {
-                    var dest = path.resolve(single_platform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.nw', file.dest);
+                    var dest = path.resolve(single_platform.releasePath, releaseFile, 'Contents', 'Resources', 'app.nw', file.dest);
                     copiedFiles.push(Utils.copyFile(file.src, dest));
                 });
             } else {
                 // zip just copy the app.nw
-                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(single_platform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'nw.icns')));
+                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(single_platform.releasePath, releaseFile, 'Contents', 'Resources', 'nw.icns')));
             }
         } else {
             // We cat the app.nw file into the .exe / nw
@@ -322,15 +334,16 @@ NwBuilder.prototype.mergeAppFiles = function () {
 NwBuilder.prototype.handleMacApp = function () {
     var self = this, allDone = [];
     var macPlatform = _.findWhere(self._platforms, {'platform':'osx'});
+    var releaseFile = (self.options.appName) ? macPlatform.app.split('%APPNAME%').join(self.options.appName).toLowerCase() : 'node-webkit.app';
     if(!macPlatform) return Promise.resolve();
 
     // Let's first handle the mac icon
     if(self.options.macIcns) {
-        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.icns')));
+        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, releaseFile, 'Contents', 'Resources', 'app.icns')));
     }
 
     // Let handle the Plist
-    var PlistPath = path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Info.plist');
+    var PlistPath = path.resolve(macPlatform.releasePath, releaseFile, 'Contents', 'Info.plist');
 
     // If the macPlist is a string we just copy the file
     if(typeof self.options.macPlist === 'String') {
@@ -406,3 +419,4 @@ NwBuilder.prototype.runApp = function () {
             process.on('SIGTERM', close);
         });
 };
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,6 @@ NwBuilder.prototype.run = function (callback) {
     return hasCallback ? true : done.promise;
 };
 
-
 NwBuilder.prototype.checkFiles = function () {
     var self = this;
 
@@ -277,7 +276,7 @@ NwBuilder.prototype.copyNodeWebkit = function () {
     this._platforms.forEach(function (single_platform) {
         single_platform.files.forEach(function (file) {
             if (single_platform.platform === 'osx' || file === single_platform.runable && self.options.appName && typeof self.options.appName === 'string') {
-                releaseFile = single_platform.app.split('%APPNAME%').join(self.options.appName).toLowerCase();
+                releaseFile = self.changeAppName(single_platform.app);
             } else {
                 releaseFile = file;
             }
@@ -314,7 +313,7 @@ NwBuilder.prototype.mergeAppFiles = function () {
     this._platforms.forEach(function (single_platform) {
         // We copy the app files if we are on mac and don't force zip
         if(single_platform.platform === 'osx') {
-            var releaseFile = (self.options.appName) ? single_platform.app.split('%APPNAME%').join(self.options.appName).toLowerCase() : 'node-webkit.app';
+            var releaseFile = self.changeAppName(single_platform.app, 'node-webkit.app');
 
             // no zip, copy the files
             if(!self.options.macZip) {
@@ -338,7 +337,7 @@ NwBuilder.prototype.mergeAppFiles = function () {
 NwBuilder.prototype.handleMacApp = function () {
     var self = this, allDone = [];
     var macPlatform = _.findWhere(self._platforms, {'platform':'osx'});
-    var releaseFile = (self.options.appName) ? macPlatform.app.split('%APPNAME%').join(self.options.appName).toLowerCase() : 'node-webkit.app';
+    var releaseFile = this.changeAppName(macPlatform.app, 'node-webkit.app');
     if(!macPlatform) return Promise.resolve();
 
     // Let's first handle the mac icon
@@ -423,5 +422,13 @@ NwBuilder.prototype.runApp = function () {
             process.on('SIGTERM', close);
         });
 };
+
+NwBuilder.prototype.changeAppName = function (appName, default_) {
+  if (typeof default_ === 'undefined') {
+    default_ = '';
+  }
+  return (this.options.appName) ? appName.split('%APPNAME%').join(this.options.appName).toLowerCase().replace(/\s+/g, '_') : default_;
+};
+
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -248,6 +248,10 @@ NwBuilder.prototype.createReleaseFolder = function () {
             releasePath = self.options.appName;
         break;
 
+        case 'root':
+            releasePath = '';
+        break;
+
         default:
             releasePath = self.options.appName;
     }
@@ -419,4 +423,5 @@ NwBuilder.prototype.runApp = function () {
             process.on('SIGTERM', close);
         });
 };
+
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -337,8 +337,9 @@ NwBuilder.prototype.mergeAppFiles = function () {
 NwBuilder.prototype.handleMacApp = function () {
     var self = this, allDone = [];
     var macPlatform = _.findWhere(self._platforms, {'platform':'osx'});
-    var releaseFile = this.changeAppName(macPlatform.app, 'node-webkit.app');
     if(!macPlatform) return Promise.resolve();
+
+    var releaseFile = this.changeAppName(macPlatform.app, 'node-webkit.app');
 
     // Let's first handle the mac icon
     if(self.options.macIcns) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -377,7 +377,8 @@ NwBuilder.prototype.runApp = function () {
 
         self.emit('log', 'Launching App');
         return new Promise(function(resolve, reject) {
-            var p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")]),
+            var src = _.isArray(self.options.files) ? self.options.files[0] : self.options.files,
+                p = spawn(executable, ['--enable-logging', src.replace(/\*[\/\*]*/,"")]),
                 exited = false,
                 close = function (code) {
                     if (!exited) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,7 @@ module.exports = {
                 });
 
                 if (typeof dest !== 'undefined') {
-                  var dest_src = dest.src.replace(/\/\*?\*+/g, '');
+                  var dest_src = path.normalize(dest.src).replace(/[\/|\\]+\*?\*+/g, '');
                   dest_path = dest.dest + file.replace(dest_src, '');
                 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,7 +66,7 @@ module.exports = {
 
                 if (typeof dest !== 'undefined') {
                   var dest_src = path.normalize(dest.src).replace(/[\/|\\]+\*?\*+/g, '');
-                  dest_path = dest.dest + file.replace(dest_src, '');
+                  dest_path = (dest.dest + file.replace(dest_src, '')).replace(/^\//, '');
                 }
 
                 destFiles.push({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,8 @@ var plist = require('plist');
 var Glob = require('simple-glob');
 var temp = require('temp');
 var archiver = require('archiver');
+var _ = require('lodash');
+var minimatch = require('minimatch');
 
 // Automatically track and cleanup files at exit
 temp.track();
@@ -28,7 +30,13 @@ module.exports = {
             jsonfile, destFiles = [],
             srcFiles = [],
             package_path,
-            matches = Glob(fileglob);
+            fileglob_ = _.map(fileglob, function(item) {
+              return item.src || item;
+            }),
+            matches = Glob(fileglob_),
+            dests = _.filter(fileglob, function(v,k) {
+              return typeof v.src === 'string' && v.src.charAt(0) !== '!';
+            });
 
         return new Promise(function(resolve, reject) {
             if(!matches.length) return reject('No files matching');
@@ -39,6 +47,7 @@ module.exports = {
                     jsonfile = self.closerPathDepth(internalFileName, jsonfile);
                     package_path = path.normalize(jsonfile.split('package.json')[0] || './');
                 }
+
                 if(!fs.lstatSync(internalFileName).isDirectory()) {
                     srcFiles.push(internalFileName);
                 }
@@ -49,9 +58,20 @@ module.exports = {
             }
 
             srcFiles.forEach(function(file) {
+                var dest_path = file.replace(package_path, '');
+
+                dest = _.find(dests, function(d) {
+                  return minimatch(file, d.src);
+                });
+
+                if (typeof dest !== 'undefined') {
+                  var dest_src = dest.src.replace(/\/\*?\*+/g, '');
+                  dest_path = dest.dest + file.replace(dest_src, '');
+                }
+
                 destFiles.push({
                     src: file,
-                    dest: file.replace(package_path, '')
+                    dest: dest_path
                 });
             });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,11 +95,9 @@ module.exports = {
     copyFile: function (src, dest) {
         return new Promise(function(resolve, reject) {
             var stats = fs.lstatSync(src);
-            fs.copy(src, dest, function (err) {
-                if(err) return reject(err);
-                fs.chmodSync(dest, stats.mode);
-                resolve();
-            });
+            fs.copySync(src, dest);
+            fs.chmodSync(dest, stats.mode);
+            resolve();
         });
     },
     mergeFiles: function (app, zipfile, chmod) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tar-fs": "^0.3.2",
     "optimist": "^0.6.1",
     "update-notifier": "^0.1.8",
-    "rcedit": "0.2.0"
+    "rcedit": "0.2.0",
+    "minimatch": "~0.2.14"
   }
 }


### PR DESCRIPTION
I've set an ability to add object { src: '...', dest: '...' } files option field. See example below.

```bash
var nw = new NwBuilder({
        files: [
           {
              src: path.resolve(__dirname, '../path/to/another/lib/**/*'),  # /home/user/me/path/to/another/lib/**/*
              dest: 'lib'  # app.nw/lib
            }
        ],
        ...
});
```

During compression or zipping, all the files from `../path/to/another/lib/**/*` will be stored to `app.nw/lib` location.