### PR TITLE
Fix EMFILE errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,8 @@ function NwBuilder(options) {
         macZip: false,
         macPlist: false,
         winIco: null,
-        argv: process.argv.slice(2)
+        argv: process.argv.slice(2),
+        maxOpenFiles: 128
     };
     // Intercept the platforms and check for the legacy platforms of 'osx' and 'win' and
     // replace with 'osx32', 'osx64', and 'win32', 'win64' respectively.
@@ -430,16 +431,24 @@ NwBuilder.prototype.mergeAppFiles = function () {
 
             // no zip, copy the files
             if(!self.options.macZip) {
-                self._files.forEach(function (file) {
-                    var dest = path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw', file.dest);
+                copiedFiles = Utils.mapChunked(
+                    self._files,
+                    self.options.maxOpenFiles,
+                    function(file) {
+                        var dest = path.resolve(
+                            self.getResourcesDirectoryPath(platform),
+                            'app.nw',
+                            file.dest
+                        );
 
-                    if(file.dest === 'package.json' && platform.platformSpecificManifest){
-                        copiedFiles.push(self.writePlatformSpecificManifest(platform, dest));
+                        if(file.dest === 'package.json' && platform.platformSpecificManifest) {
+                            return self.writePlatformSpecificManifest(platform, dest);
+                        }
+                        else {
+                            return Utils.copyFile(file.src, dest, self);
+                        }
                     }
-                    else {
-                        copiedFiles.push(Utils.copyFile(file.src, dest, self));
-                    }
-                });
+                );
             } else {
                 // zip just copy the app.nw
                 copiedFiles.push(Utils.copyFile(

--- a/lib/index.js
+++ b/lib/index.js
@@ -422,52 +422,52 @@ NwBuilder.prototype.zipAppFiles = function () {
 };
 
 NwBuilder.prototype.mergeAppFiles = function () {
-    var self = this,
-        copiedFiles = [];
+    var self = this;
 
-    this._forEachPlatform(function (name, platform) {
-        // We copy the app files if we are on mac and don't force zip
-        if(name === 'osx32' || name === 'osx64') {
+    return Promise.all(_.foldl(
+        this._platforms,
+        function(acc, platform, name) {
+            var next = null;
+            if(name === 'osx32' || name === 'osx64') {
+                if(!self.options.macZip) {
+                    next = Utils.mapChunked(
+                        self._files,
+                        self.options.maxOpenFiles,
+                        function(file) {
+                            var dest = path.resolve(
+                                self.getResourcesDirectoryPath(platform),
+                                'app.nw',
+                                file.dest
+                            );
 
-            // no zip, copy the files
-            if(!self.options.macZip) {
-                copiedFiles = Utils.mapChunked(
-                    self._files,
-                    self.options.maxOpenFiles,
-                    function(file) {
-                        var dest = path.resolve(
-                            self.getResourcesDirectoryPath(platform),
-                            'app.nw',
-                            file.dest
-                        );
-
-                        if(file.dest === 'package.json' && platform.platformSpecificManifest) {
-                            return self.writePlatformSpecificManifest(platform, dest);
+                            if(file.dest === 'package.json' && platform.platformSpecificManifest) {
+                                return self.writePlatformSpecificManifest(platform, dest);
+                            }
+                            else {
+                                return Utils.copyFile(file.src, dest, self);
+                            }
                         }
-                        else {
-                            return Utils.copyFile(file.src, dest, self);
-                        }
-                    }
-                );
+                    );
+                } else {
+                    // zip just copy the app.nw
+                    next = Utils.copyFile(
+                        self.getZipFile(name),
+                        path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw'),
+                        self
+                    );
+                }
             } else {
-                // zip just copy the app.nw
-                copiedFiles.push(Utils.copyFile(
+                // We cat the app.nw file into the .exe / nw
+                next = Utils.mergeFiles(
+                    path.resolve(platform.releasePath, _.first(platform.files)),
                     self.getZipFile(name),
-                    path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw'),
-                    self
-                ));
+                    platform.chmod
+                );
             }
-        } else {
-            // We cat the app.nw file into the .exe / nw
-            copiedFiles.push(Utils.mergeFiles(
-                path.resolve(platform.releasePath, _.first(platform.files)),
-                self.getZipFile(name),
-                platform.chmod
-            ));
-        }
-    });
-
-    return Promise.all(copiedFiles);
+            return acc.then(function() { return next; })
+        },
+        new Promise(function(resolve, reject) { resolve(); })
+    ));
 };
 
 NwBuilder.prototype.getZipFile = function(platformName){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,15 @@ var writeFile = Promise.promisify(fs.writeFile);
 // Automatically track and cleanup files at exit
 temp.track();
 
+_.mixin({
+  'chunk': function (collection, chunkSize) {
+    if (!collection || _.isNaN(parseInt(chunkSize, 10))) { return [];}
+    return _.toArray(_.groupBy(collection, function (iterator, index) {
+      return Math.floor(index / parseInt(chunkSize, 10));
+    }));
+  }
+});
+
 module.exports = {
     getPackageInfo: function(path) {
         return new Promise(function(resolve, reject) {
@@ -253,5 +262,18 @@ module.exports = {
                 // Write output file
                 return writeFile(plistOutput, plist.build(info));
             });
+    },
+    mapChunked: function(xs, chunksize, f) {
+        return Promise.all(_.foldl(
+            _.chunk(xs, chunksize),
+            function(acc, chunk) {
+                return acc.then(function() {
+                    return Promise.all(
+                        _.map(chunk, function(val) { return f(val); })
+                    );
+                })
+            },
+            new Promise(function(resolve, reject) { resolve(); })
+        ));
     }
 };


### PR DESCRIPTION
I was still receiving `EMFILE` errors after all and had a closer look at the copy code.

The problem is that the current implementation will launch all copy calls at once, essentially opening possibly thousands of read- and write-streams at the same time.

This patch introduces a method called `mapChunked` that allows us to chunk up the number of parallel copy processes by setting the `chunksize` to something reasonable. This number is driven by `options.maxOpenFiles` but we can rename this if required. I chose not to do any fancy figuring out how many parallel opened files are ok per system code as I feel this is something that a client to the library should be doing.

So far, I have applied the technique only to `mergeAppFiles` but if this patch is approved as a reasonable way forward, it would likely make sense to apply the function to all places where a lot of files are processed at once.

*Note*: I used [this gist](https://gist.github.com/dannycroft/7647231) to save myself the time backporting lodash's `chunk` method to 2.x. Finally, here ia a [proof of concept](https://gist.github.com/felixSchl/8955008908385033e369) of the employed approach.