### PR TITLE
Do not expand `files`, add `fileglob`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,8 @@ module.exports = NwBuilder;
 function NwBuilder(options) {
     var self = this;
     var defaults = {
-        files: null,
+        files: [],
+        fileglob: null,
         appName: false,
         appVersion: false,
         platforms: ['osx32', 'osx64', 'win32', 'win64'],
@@ -58,8 +59,8 @@ function NwBuilder(options) {
     this._platforms = platforms;
 
     // Some Option checking
-    if(!this.options.files) {
-        throw new Error('Please specify some files');
+    if(!(this.options.files.length || this.options.fileglob)) {
+        throw new Error('Please specify some files or a globbing pattern');
     }
 
     if (this.options.platforms.length === 0)
@@ -149,7 +150,10 @@ NwBuilder.prototype.run = function (callback) {
 NwBuilder.prototype.checkFiles = function () {
     var self = this;
 
-    return Utils.getFileList(this.options.files).then(function (data) {
+    return Utils.getFileList(
+        this.options.files,
+        this.options.fileglob
+    ).then(function (data) {
 
         self._appPkg = data.json;
         self._files = data.files;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,12 +32,12 @@ module.exports = {
             });
         });
     },
-    getFileList: function(fileglob) {
+    getFileList: function(files, fileglob) {
         var self = this,
             jsonfile, destFiles = [],
             srcFiles = [],
             package_path,
-            matches = Glob(fileglob);
+            matches = _.unique(files.concat(fileglob ? Glob(fileglob) : []));
 
         return new Promise(function(resolve, reject) {
             if(!matches.length) return reject('No files matching');

--- a/test/nwBuilder.js
+++ b/test/nwBuilder.js
@@ -31,7 +31,7 @@ test('Should check if we have some files', function (t) {
     t.plan(2);
 
     var x = new NwBuilder({
-        files: './test/fixtures/nwapp/**/*'
+        fileglob: './test/fixtures/nwapp/**/*'
     });
 
     x.checkFiles().then(function (data) {
@@ -45,7 +45,7 @@ test('Should take the option name if provided', function (t) {
     t.plan(1);
 
     var x = new NwBuilder({
-        files: './test/fixtures/nwapp/**/*',
+        fileglob: './test/fixtures/nwapp/**/*',
         appName: 'somename'
     });
 
@@ -58,7 +58,7 @@ test('Should check if we have some files: rejection', function (t) {
     t.plan(1);
 
     var x = new NwBuilder({
-        files: './test/fixtures/nwapp/images/**'
+        fileglob: './test/fixtures/nwapp/images/**'
     });
 
     x.checkFiles().catch(function (error) {
@@ -71,7 +71,7 @@ test('Should apply platform-specific overrides correctly', function (t) {
     t.plan(6);
 
     var x = new NwBuilder({
-            files: './test/fixtures/platformOverrides/**/*',
+            fileglob: './test/fixtures/platformOverrides/**/*',
             platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64']
         });
 
@@ -89,7 +89,7 @@ test('Should only create one ZIP if there are no platform-specific overrides', f
     t.plan(17);
 
     var x = new NwBuilder({
-        files: './test/fixtures/nwapp/**/*',
+        fileglob: './test/fixtures/nwapp/**/*',
         platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
         macZip: true
     });
@@ -115,7 +115,7 @@ test('Should create a ZIP per platform if every platform has overrides', functio
     t.plan(15);
 
     var x = new NwBuilder({
-        files: './test/fixtures/platformOverrides/**/*',
+        fileglob: './test/fixtures/platformOverrides/**/*',
         platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
         macZip: true
     });
@@ -139,7 +139,7 @@ test('Should create a ZIP per platform which has overrides and one between the r
     t.plan(15);
 
     var x = new NwBuilder({
-        files: './test/fixtures/oneOveriddenRestNot/**/*',
+        fileglob: './test/fixtures/oneOveriddenRestNot/**/*',
         platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
         macZip: true
     });
@@ -163,7 +163,7 @@ test('Should find latest version', function (t) {
     t.plan(2);
 
     var x = new NwBuilder({
-        files: '**',
+        fileglob: '**',
         version: 'latest'
     });
 
@@ -181,7 +181,7 @@ test('Should not accept an invalid version', function (t) {
     t.plan(1);
 
     var x = new NwBuilder({
-        files: '**',
+        fileglob: '**',
         version: '1.blah.0'
     });
 
@@ -194,7 +194,7 @@ test('Should not accept an invalid version', function (t) {
 test('Should not zip mac apps by default', function (t) {
     t.plan(1);
 
-    var x = new NwBuilder({ files: './test/fixtures/nwapp/**/*', platforms: ['osx32', 'osx64'] });
+    var x = new NwBuilder({ fileglob: './test/fixtures/nwapp/**/*', platforms: ['osx32', 'osx64'] });
     x.zipAppFiles().then(function () {
         t.notOk(x._needsZip);
     });
@@ -212,7 +212,7 @@ testSetup({
     var appName = 'theapp',
         buildDir = './test/temp/oneOverridenRestNot',
         x = new NwBuilder({
-            files: './test/fixtures/oneOveriddenRestNot/**/*',
+            fileglob: './test/fixtures/oneOveriddenRestNot/**/*',
             platforms: ['osx32'],
             appName: appName,
             buildDir: buildDir

--- a/test/utils.js
+++ b/test/utils.js
@@ -78,7 +78,7 @@ test('generate and write a valid plist file', function (t) {
 test('getFileList', function (t) {
     t.plan(5);
 
-    utils.getFileList('./test/fixtures/nwapp/**').then(function(data) {
+    utils.getFileList([], './test/fixtures/nwapp/**').then(function(data) {
         t.equal(data.json, path.normalize('test/fixtures/nwapp/package.json'), 'figure out the right json');
         var expected = [{
             "src" : path.normalize("test/fixtures/nwapp/images/imagefile.img"),
@@ -102,17 +102,17 @@ test('getFileList', function (t) {
         t.deepEqual(data.files, expected);
     });
 
-    utils.getFileList('./test/fixtures/nwapp/images/**').then(function(data) {
+    utils.getFileList([], './test/fixtures/nwapp/images/**').then(function(data) {
     }, function (error) {
         t.equal(error, 'Could not find a package.json in your src folder', 'throw an error if there is no package json');
     });
 
-    utils.getFileList('./test/fixtures/nwapp/images/*.js').then(function(data) {
+    utils.getFileList([], './test/fixtures/nwapp/images/*.js').then(function(data) {
     }, function (error) {
         t.equal(error, 'No files matching');
     });
 
-    utils.getFileList(['./test/fixtures/nwapp/**/*', '!./test/fixtures/nwapp/node_modules/**/*',  '!./test/fixtures/nwapp/javascript/**/*']).then(function(data) {
+    utils.getFileList([], ['./test/fixtures/nwapp/**/*', '!./test/fixtures/nwapp/node_modules/**/*',  '!./test/fixtures/nwapp/javascript/**/*']).then(function(data) {
         var expected = [{
             "src" : path.normalize("test/fixtures/nwapp/images/imagefile.img"),
             "dest": path.normalize("images/imagefile.img")


### PR DESCRIPTION
The first argument to `utils.getFileList` is now a list of already
expanded files, the second argument is a list of fileglob patterns.

Boths lists are concatenated after expansion and made unique.

This allows a user to specify a set of known files or have node webkit
builder expand it on the fly. This is particularily interesting for
grunt, which does the file expansion already.

This changes the `NwBuilder` interface with a backwards incompatible
manner: The constructor now takes both a `files` and a `fileglob`
array. However, what is now called `fileglob` was previously called
`files` and will *NOT* be expanded further.

This is one possible implementation to resolve #171