### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -561,7 +561,7 @@ NwBuilder.prototype.runApp = function () {
 
     self.emit('log', 'Launching App');
     return new Promise(function(resolve, reject) {
-        var p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
+        var p = spawn(executable, [self.options.files.replace(/\*[\/\*]*/,"")]);
 
         p.stdout.on('data', function(data) {
             self.emit('stdout', data);


### PR DESCRIPTION
Issues:
- Whenever you try to run `Builder.run()`, a folder named `--enable-logging` is created in the application source directory.
- `concat` results in the same output as above but with a `run` folder instead.