### PR TITLE
added option for winZip similar to macZip

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,15 @@ MAC ONLY: Pass a string containing the path to your own plist file. If a string 
 
 #### options.winIco
 Type: `String`  
-Default value: `null`  
+Default value: `null`
 
 WINDOWS ONLY: The path to your ICO icon file. If your don't provide your own it will use the one provided by node-webkit. If you are building on MAC or LINUX you must have [Wine](http://winehq.org) installed to use this option.
+
+#### options.winZip
+Type: `Boolean`
+Default value: `true`
+
+WINDOW ONLY: Instead of placing the application content inside the .exe file. The application content is placed next to the application.
 
 ### Manifest Options
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ MAC ONLY: The path to your ICNS icon file. If your don't provide your own it wil
 
 #### options.macZip
 Type: `Boolean`  
-Default value: `false`  
+Default value: `null`
 
-MAC ONLY: Use a `app.nw` folder instead of `ZIP` file, this significantly improves the startup speed of applications on `mac`, since no decompressing is needed. Builds on other platforms will still use `ZIP` files.
+MAC ONLY: Use a `app.nw` folder instead of `ZIP` file, this significantly improves the startup speed of applications on `mac`, since no decompressing is needed. Builds on other platforms will still use `ZIP` files. The default behaviour of node-webkit-builder is to not use `ZIP` files on the `mac` platform. In case of the `mac` platform the option `macZip` can override the option `zip`.
 
 #### options.macPlist
 Type: `String` or `Object`  
@@ -162,11 +162,11 @@ Default value: `null`
 
 WINDOWS ONLY: The path to your ICO icon file. If your don't provide your own it will use the one provided by node-webkit. If you are building on MAC or LINUX you must have [Wine](http://winehq.org) installed to use this option.
 
-#### options.winZip
+#### options.zip
 Type: `Boolean`
-Default value: `true`
+Default value: `null`
 
-WINDOW ONLY: Instead of placing the application content inside the .exe file. The application content is placed next to the application.
+WINDOW ONLY: Instead of zipping the application and merging it into the executable the application content is placed next to the application. The default behaviour is platform specific. In case of `windows` and `linux` the application is zipped and merged into the executable. In case of the `mac` platform the application is not zipped.
 
 ### Manifest Options
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ function NwBuilder(options) {
         macCredits: false,
         macIcns: false,
         macZip: false,
+        winZip: true,
         macPlist: false,
         winIco: null,
         argv: process.argv.slice(2)
@@ -365,8 +366,15 @@ NwBuilder.prototype.zipAppFiles = function () {
     self._zips = {};
 
     this._forEachPlatform(function(name, platform) {
-        if((name === 'osx32' || name === 'osx64') && self.options.macZip || platform.needsZip) {
-            _needsZip = true;
+        _needsZip = platform.needsZip;
+
+        if(name === 'osx32' || name == 'osx64') {
+            _needsZip = self.options.macZip;
+        } else if(name == 'win32' || name == 'win64') {
+            _needsZip = self.options.winZip;
+        }
+
+        if(_needsZip) {
             var platformSpecific = !!platform.platformSpecificManifest;
 
             self._zips[name] = { platformSpecific: platformSpecific };
@@ -424,41 +432,48 @@ NwBuilder.prototype.mergeAppFiles = function () {
     var self = this,
         copiedFiles = [];
 
+    var copyPromise = Promise.resolve();
+
     this._forEachPlatform(function (name, platform) {
         // We copy the app files if we are on mac and don't force zip
-        if(name === 'osx32' || name === 'osx64') {
+        if(((name === 'osx32' || name === 'osx64') && !self.options.macZip)
+         || ((name === 'win32' || name === 'win64') && !self.options.winZip)) {
 
             // no zip, copy the files
-            if(!self.options.macZip) {
-                self._files.forEach(function (file) {
-                    var dest = path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw', file.dest);
+            self._files.forEach(function (file) {
+                var dest;
 
-                    if(file.dest === 'package.json' && platform.platformSpecificManifest){
-                        copiedFiles.push(self.writePlatformSpecificManifest(platform, dest));
-                    }
-                    else {
-                        copiedFiles.push(Utils.copyFile(file.src, dest, self));
-                    }
-                });
-            } else {
-                // zip just copy the app.nw
-                copiedFiles.push(Utils.copyFile(
-                    self.getZipFile(name),
-                    path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw'),
-                    self
-                ));
-            }
+                if(name == 'osx32' || name === 'osx64') {
+                    dest = path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw', file.dest);
+                } else {
+                    dest = path.resolve(platform.releasePath, file.dest);
+                }
+
+                if(file.dest === 'package.json' && platform.platformSpecificManifest){
+                    copyPromise = copyPromise.then(function(){ return self.writePlatformSpecificManifest(platform, dest) } );
+                }
+                else {
+                    copyPromise = copyPromise.then(function(){ return Utils.copyFile(file.src, dest, self) });
+                }
+            });
+        } else if(name == 'osx32' || name == 'osx64') {
+            // zip just copy the app.nw
+            copyPromise = copyPromise.then(function(){ return Utils.copyFile(
+                self.getZipFile(name),
+                path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw'),
+                self
+            ) });
         } else {
             // We cat the app.nw file into the .exe / nw
-            copiedFiles.push(Utils.mergeFiles(
+            copyPromise = copyPromise.then(function(){ return Utils.mergeFiles(
                 path.resolve(platform.releasePath, _.first(platform.files)),
                 self.getZipFile(name),
                 platform.chmod
-            ));
+            )});
         }
     });
 
-    return Promise.all(copiedFiles);
+    return copyPromise;
 };
 
 NwBuilder.prototype.getZipFile = function(platformName){

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,8 +35,8 @@ function NwBuilder(options) {
         forceDownload: false,
         macCredits: false,
         macIcns: false,
-        macZip: false,
-        winZip: true,
+        macZip: null,
+        zip: null,
         macPlist: false,
         winIco: null,
         argv: process.argv.slice(2)
@@ -356,6 +356,19 @@ NwBuilder.prototype.copyNodeWebkit = function () {
     return Promise.all(copiedFiles);
 };
 
+NwBuilder.prototype.isPlatformNeedingZip = function(name, platform) {
+    var self = this,
+        needsZip = platform.needsZip;
+
+    if(name.indexOf('osx') === 0 && self.options.macZip != null) {
+        needsZip = self.options.macZip;
+    } else if(self.options.zip != null) {
+        needsZip = self.options.zip;
+    }
+
+    return needsZip;
+}
+
 NwBuilder.prototype.zipAppFiles = function () {
     var self = this;
 
@@ -366,13 +379,7 @@ NwBuilder.prototype.zipAppFiles = function () {
     self._zips = {};
 
     this._forEachPlatform(function(name, platform) {
-        _needsZip = platform.needsZip;
-
-        if(name === 'osx32' || name == 'osx64') {
-            _needsZip = self.options.macZip;
-        } else if(name == 'win32' || name == 'win64') {
-            _needsZip = self.options.winZip;
-        }
+        _needsZip = self.isPlatformNeedingZip(name, platform);
 
         if(_needsZip) {
             var platformSpecific = !!platform.platformSpecificManifest;
@@ -435,10 +442,9 @@ NwBuilder.prototype.mergeAppFiles = function () {
     var copyPromise = Promise.resolve();
 
     this._forEachPlatform(function (name, platform) {
+        var zipping = self.isPlatformNeedingZip(name, platform);
         // We copy the app files if we are on mac and don't force zip
-        if(((name === 'osx32' || name === 'osx64') && !self.options.macZip)
-         || ((name === 'win32' || name === 'win64') && !self.options.winZip)) {
-
+        if(!zipping) {
             // no zip, copy the files
             self._files.forEach(function (file) {
                 var dest;

--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -20,6 +20,7 @@ module.exports = {
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-x64.zip'
     },
     osx32: {
+        needsZip: false,
         getRunnable: function(version) {
             if(semver.satisfies(version, '>=0.12.0 || ~0.12.0-alpha')) {
                 return 'nwjs.app/Contents/MacOS/nwjs';
@@ -34,6 +35,7 @@ module.exports = {
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-osx-ia32.zip'
     },
     osx64: {
+        needsZip: false,
         getRunnable: function(version) {
             if(semver.satisfies(version, '>=0.12.0 || ~0.12.0-alpha')) {
                 return 'nwjs.app/Contents/MacOS/nwjs';


### PR DESCRIPTION
As large projects might result in slow application startup times, I suggest the following changes to introduce a winZip option. This option defaults to true (which leaves node-webkit-builder's behavior unchanged) and can be set to false to allow putting the application uncompressed next to the executable.

See:
https://github.com/mllrsohn/node-webkit-builder/issues/195