### PR TITLE
Fixing __MACOSX edge-case

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -154,6 +154,14 @@ module.exports = {
         return done.promise;
     },
     stripRootFolder: function(extracted){
+        
+        // Strip __MACOSX folder from rootFiles
+        var rootFolders = fs.readdirSync(extracted.destination);
+        for (var i = 0; i < rootFolders.length; i++) {
+          var folder = rootFolders[i];
+          if (folder === '__MACOSX') rimraf.sync(extracted.destination + path.sep + folder);
+        };
+        
         var done = Promise.defer(),
             files = extracted.files,
             destination = extracted.destination,


### PR DESCRIPTION
This fixes the edge-case of having a __MACOSX folder inside the zip, which will break the logic defined on line 172 since the rootFiles array will have a length of 2 instead of 1.

Fixes https://github.com/Soundnode/soundnode-app/pull/228