### PR TITLE
put upper bound to semver check for windows

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -6,7 +6,7 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
             '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-ia32.zip'
@@ -16,7 +16,7 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
             '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-x64.zip'


### PR DESCRIPTION
This avoids this version matching if evaluated before the next rule
(>=0.12.0) which would end up not including files like pdf.dll