### PR TITLE
Added platform check for OSX32 and rejected build operation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,7 @@ NwBuilder.prototype.build = function (callback) {
     this.checkFiles().bind(this)
         .then(this.resolveLatestVersion)
         .then(this.checkVersion)
+        .then(this.checkPlatform)
         .then(this.platformFilesForVersion)
         .then(this.downloadNodeWebkit)
         .then(this.preparePlatformSpecificManifests)
@@ -124,6 +125,7 @@ NwBuilder.prototype.run = function (callback) {
     this.checkFiles().bind(this)
         .then(this.resolveLatestVersion)
         .then(this.checkVersion)
+        .then(this.checkPlatform)
         .then(this.platformFilesForVersion)
         .then(this.downloadNodeWebkit)
         .then(this.runApp)
@@ -190,6 +192,15 @@ NwBuilder.prototype.checkVersion = function () {
     return Promise.resolve();
 };
 
+NwBuilder.prototype.checkPlatform = function(){
+
+    if(this.options.platforms.indexOf("osx32") > -1){
+
+        return Promise.reject("osx32 support has been discontinued.");
+    }
+    return Promise.resolve();
+};
+
 NwBuilder.prototype.platformFilesForVersion = function () {
     var self = this;
 
@@ -237,7 +248,7 @@ NwBuilder.prototype.downloadNodeWebkit = function () {
                         if(err.statusCode === 404){
                             self.emit('log', 'ERROR: The version '+self._version.version+' does not have a corresponding build posted at ' + self.options.downloadUrl + '. Please choose a version from that list.')
                         } else {
-                            self.emit('log', err.msg)
+                            self.emit('log', err.msg);
                         }
 
                         return Promise.reject('Unable to download nodewebkit.');


### PR DESCRIPTION
If OSX32 is present in the list of platforms, all builds will break. Because of that build will now be rejected if osx32 is given