### PR TITLE
Fatal error: path must be a string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -393,9 +393,11 @@ NwBuilder.prototype.zipAppFiles = function () {
 
             numberOfPlatformsWithoutOverrides += !platformSpecific;
         }
+        
+        self._needsZip = self._needsZip || _needsZip;
     });
-
-    self._needsZip = _needsZip;
+    //when build win32 _needsZip is true ,then build osx32 _needsZip is false,but _needsZip is global 
+    //self._needsZip = _needsZip;
 
     return new Promise(function(resolve, reject) {
 


### PR DESCRIPTION
when build win32 _needsZip is true ,then build osx32 _needsZip is false,but _needsZip is global 