### PR TITLE
v1.13.* files for Linux and Windows

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -7,7 +7,8 @@ module.exports = {
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
             '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
-            '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
+            '>=0.12.0 <0.13.0-alpha3': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll'],
+            '>=0.13.0-alpha3': ['nw.exe', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw_100_percent.pak', 'nw_200_percent.pak', 'locales', 'd3dcompiler_47.dll', 'natives_blob.bin', 'node.dll', 'nw_elf.dll', 'nw.dll', 'resources.pak', 'snapshot_blob.bin']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-ia32.zip'
     },
@@ -17,7 +18,8 @@ module.exports = {
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
             '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
-            '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
+            '>=0.12.0 <0.13.0-alpha3': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll'],
+            '>=0.13.0-alpha3': ['nw.exe', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw_100_percent.pak', 'nw_200_percent.pak', 'locales', 'd3dcompiler_47.dll', 'natives_blob.bin', 'node.dll', 'nw_elf.dll', 'nw.dll', 'resources.pak', 'snapshot_blob.bin']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-x64.zip'
     },
@@ -58,7 +60,8 @@ module.exports = {
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
             '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],
-            '>0.10.1':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales']
+            '>0.10.1 <0.13.0-alpha3':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales'],
+            '>=0.13.0-alpha3':         ['nw', 'nw.pak', 'lib', 'icudtl.dat', 'locales', 'natives_blob.bin', 'nw_100_percent.pak', 'resources.pak', 'snapshot_blob.bin']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-linux-ia32.tar.gz'
     },
@@ -69,7 +72,8 @@ module.exports = {
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
             '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],
-            '>0.10.1':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales']
+            '>0.10.1 <0.13.0-alpha3':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales'],
+            '>=0.13.0-alpha3':         ['nw', 'nw.pak', 'lib', 'icudtl.dat', 'locales', 'natives_blob.bin', 'nw_100_percent.pak', 'resources.pak', 'snapshot_blob.bin']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-linux-x64.tar.gz'
     }


### PR DESCRIPTION
Makes nw-builder work with v1.13 on Windows provided zip option is set to false. I wonder if the app payload is still supposed to be concatenated to nw.exe/nw from v0.13.

Addresses #254 and #275.