### PR TITLE
Allow zip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ Default value: `null`
 
 WINDOW ONLY: Instead of zipping the application and merging it into the executable the application content is placed next to the application (which speed up the startup time for large apps). The default behaviour is platform specific. For `windows` and `linux`, the application is zipped and merged into the executable. For `mac`, the application is not zipped.
 
+#### options.zipOptions
+Type: `Object`
+Default value: `null`
+
+Allows to configure the underling zip library parameters, like store or compression ratio.
+
+See [archiver](http://archiverjs.com/docs/global.html#ZipOptions) documentation for detailed description of properties.
+
 #### options.macPlist
 Type: `String` or `Object`  
 Default value: `false`  

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ function NwBuilder(options) {
         macIcns: false,
         macZip: null,
         zip: null,
+        zipOptions: null,
         macPlist: false,
         winIco: null,
         argv: process.argv.slice(2)
@@ -379,6 +380,7 @@ NwBuilder.prototype.zipAppFiles = function () {
 
     // Check if zip is needed
     var _needsZip = false,
+        zipOptions = this.options.zipOptions;
         numberOfPlatformsWithoutOverrides = 0;
 
     self._zips = {};
@@ -408,7 +410,7 @@ NwBuilder.prototype.zipAppFiles = function () {
         // create (or don't create) a ZIP for multiple platforms
         new Promise(function(resolve, reject) {
             if(numberOfPlatformsWithoutOverrides > 1){
-                Utils.generateZipFile(self._files, self).then(function (zip) {
+                Utils.generateZipFile(self._files, self, null, zipOptions).then(function (zip) {
                     resolve(zip);
                 }, reject);
             }
@@ -429,7 +431,8 @@ NwBuilder.prototype.zipAppFiles = function () {
                     zipPromises.push(Utils.generateZipFile(
                         self._files,
                         self,
-                        JSON.stringify(self._platforms[platformName].platformSpecificManifest)
+                        JSON.stringify(self._platforms[platformName].platformSpecificManifest),
+                        zipOptions
                     ).then(function(file){
                             zip.file = file;
                         }));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,9 +132,9 @@ module.exports = {
             zipStream.pipe(writeStream);
         });
     },
-    generateZipFile: function (files, _event, platformSpecificManifest) {
+    generateZipFile: function (files, _event, platformSpecificManifest, zipOptions) {
         var destStream = temp.createWriteStream(),
-            archive = archiver('zip');
+            archive = archiver('zip', zipOptions || {});
 
         return new Promise(function(resolve, reject) {
 


### PR DESCRIPTION
This is a follow up of #282

This will allow fine tune how the zip file is created. 

Example:
```js
    nwjs: {
      options: {
        platforms: ['...'],
        zip: true,
        zipOptions: {
          store: false,
          level: 8,
        }
    }
```
