### PR TITLE
add currentPlatform option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function NwBuilder(options) {
         appName: false,
         appVersion: false,
         platforms: ['osx32', 'osx64', 'win32', 'win64'],
-        currentPlatform: detectCurrentPlatform(),
+        currentPlatform: options.currentPlatform || detectCurrentPlatform(),
         version: 'latest',
         buildDir: './build',
         cacheDir: './cache',


### PR DESCRIPTION
allows to run 32bits executables on 64bits machines. optionnal flag.

fix #310