### PR TITLE
Supporting newer NW.js versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ cache
 tmp/
 test/temp/
 .DS_Store
+
+example/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "4.0"
+  - "6.0"
 notifications:
   webhooks:
     urls:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.11"
+    - nodejs_version: "4.0"
+    - nodejs_version: "6.0"
 
 # Allow failing jobs for bleeding-edge Node.js versions.
 matrix:

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -1,16 +1,15 @@
-var NwBuilder = require('../');
+var NwBuilder = require('nw-builder');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 
 gulp.task('nw', function () {
 
     var nw = new NwBuilder({
-        version: '0.15.3',
+        version: '0.11.0',
         files: './nwapp/**',
         macIcns: './icons/icon.icns',
         macPlist: {mac_bundle_id: 'myPkg'},
-        //platforms: ['win32', 'win64', 'osx32', 'osx64']
-        platforms: ['linux32', 'linux64']
+        platforms: ['win32', 'win64', 'osx32', 'osx64']
     });
 
     // Log stuff you want

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -1,15 +1,16 @@
-var NwBuilder = require('nw-builder');
+var NwBuilder = require('../');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 
 gulp.task('nw', function () {
 
     var nw = new NwBuilder({
-        version: '0.11.0',
+        version: '0.15.3',
         files: './nwapp/**',
         macIcns: './icons/icon.icns',
         macPlist: {mac_bundle_id: 'myPkg'},
-        platforms: ['win32', 'win64', 'osx32', 'osx64']
+        //platforms: ['win32', 'win64', 'osx32', 'osx64']
+        platforms: ['linux32', 'linux64']
     });
 
     // Log stuff you want

--- a/lib/Version.js
+++ b/lib/Version.js
@@ -1,0 +1,49 @@
+var platforms   = require('./platforms');
+var _           = require('lodash');
+var semver      = require('semver');
+
+// TODO: js doc
+// version, supportedPlatforms, downloadUrl
+module.exports = function Version(args){
+    var generatePlatformUrls,
+        result = {
+            isLegacy: semver.satisfies(args.version, '<0.12.3'),
+            name: semver.satisfies(args.version, '>=0.12.0 || ~0.12.0-alpha') ? 'nwjs' : 'node-webkit',
+            version: args.version
+        };
+
+    if(result.isLegacy){
+        generatePlatformUrls = function(version, supportedPlatforms){
+            var platformUrls = {};
+            supportedPlatforms.forEach(function (supportedPlatform) {
+                platformUrls[supportedPlatform] = args.downloadUrl + _.template(platforms[supportedPlatform].versionNameTemplate, result);
+            });
+            return platformUrls;
+        };
+    }
+    else {
+        var fixPlatformName = function(platform){
+            return platform.replace('32', '-ia32').replace('64', '-x64');
+        };
+
+        var mapPlatformToExtension = function(platform){
+            if(platform.indexOf('linux') === 0){
+                return 'tar.gz'
+            }
+
+            return 'zip'
+        };
+
+        generatePlatformUrls = function(version, supportedPlatforms){
+            var platformUrls = {};
+            supportedPlatforms.forEach(function(platform){
+                platformUrls[platform] = args.downloadUrl + 'v' + version + '/nwjs-sdk-v' + version + '-' + fixPlatformName(platform)
+                    + '.' + mapPlatformToExtension(platform);
+            });
+            return platformUrls;
+        };
+    }
+
+    result.platforms = generatePlatformUrls(args.version, args.supportedPlatforms);
+    return result;
+};

--- a/lib/Version.js
+++ b/lib/Version.js
@@ -17,7 +17,8 @@ module.exports = function Version(args){
             version: args.version
         };
 
-    if(result.isLegacy){
+    // 0.12.3 is an exception that is in the manifest but is pretty much a legacy version
+    if(result.isLegacy || args.version === '0.12.3'){
         generatePlatformUrls = function(version, supportedPlatforms){
             var platformUrls = {};
             supportedPlatforms.forEach(function (supportedPlatform) {

--- a/lib/Version.js
+++ b/lib/Version.js
@@ -2,8 +2,13 @@ var platforms   = require('./platforms');
 var _           = require('lodash');
 var semver      = require('semver');
 
-// TODO: js doc
-// version, supportedPlatforms, downloadUrl
+/**
+ * Represents a version.
+ * @constructor
+ * @param {string} args.version.
+ * @param {array} args.supportedPlatforms - array of strings like `osx64`.
+ * @param {string} args.downloadUrl.
+ */
 module.exports = function Version(args){
     var generatePlatformUrls,
         result = {

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -24,7 +24,7 @@ module.exports = {
         // if the version is >=0.12.3, then we don't which files we want from the archives, so just check that the folder
         // exists and has at least 4 files in it.
         if(files.length === 1 && files[0] === '*'){
-            return fs.readdirSync(cachepath).length > 3;
+            return fs.existsSync(cachepath) && fs.readdirSync(cachepath).length > 3;
         }
 
         files.forEach(function(file) {

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -20,6 +20,13 @@ var bar;
 module.exports = {
     checkCache: function(cachepath, files) {
         var missing;
+
+        // if the version is >=0.12.3, then we don't which files we want from the archives, so just check that the folder
+        // exists and has at least 4 files in it.
+        if(files.length === 1 && files[0] === '*'){
+            return fs.readdirSync(cachepath).length > 3;
+        }
+
         files.forEach(function(file) {
             if (missing) {
                 return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,9 @@ NwBuilder.prototype.checkVersion = function () {
     .then(function(version){
         self._version = version;
         self.emit('log', 'Using v' + self._version.version);
+        if(self._version.isLegacy) {
+            deprecate('NW.js / node-webkit versions <0.12.3 are deprecated.');
+        }
     });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -535,23 +535,7 @@ NwBuilder.prototype.mergeAppFiles = function () {
                 self
             ));
         } else {
-            var executableToMergeWith;
-
-            if(self._version.isLegacy){
-                executableToMergeWith = _.first(platform.files);
-            }
-            else {
-                var executableExtension = '';
-
-                if(name.indexOf('osx') === 0){
-                    executableExtension = '.app';
-                }
-                else if(name.indexOf('win') === 0){
-                    executableExtension = '.exe';
-                }
-
-                executableToMergeWith = self.options.appName + executableExtension;
-            }
+            var executableToMergeWith = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
 
             // We cat the app.nw file into the .exe / nw
             copyPromises.push(Utils.mergeFiles(
@@ -632,10 +616,11 @@ NwBuilder.prototype.handleWinApp = function () {
         // build a promise chain
         allDone.push(new Promise(function(resolve, reject) {
             self.emit('log', 'Update ' + name + ' executable icon');
+            var executableName = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
             // Set icon
             winresourcer({
                 operation: "Update",
-                exeFile: path.resolve(platform.releasePath, _.first(platform.files)),
+                exeFile: path.resolve(platform.releasePath, executableName),
                 resourceType: "Icongroup",
                 resourceName: "IDR_MAINFRAME",
                 lang: 1033, // Required, except when updating or deleting
@@ -707,4 +692,18 @@ NwBuilder.prototype._forEachPlatform = function (fn) {
 // Mac only
 NwBuilder.prototype.getResourcesDirectoryPath = function (platform) {
     return path.resolve(platform.releasePath, this.options.appName+'.app', 'Contents', 'Resources');
+};
+
+// Don't use if legacy version
+NwBuilder.prototype.getExecutableName = function (platform) {
+    var executableExtension = '';
+
+    if(platform.indexOf('osx') === 0){
+        executableExtension = '.app';
+    }
+    else if(platform.indexOf('win') === 0){
+        executableExtension = '.exe';
+    }
+
+    return this.options.appName + executableExtension;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -381,7 +381,7 @@ NwBuilder.prototype.copyNwjs = function () {
                 var destFile = path.relative(platform.cache, file);
                 var options = {};
 
-                if(['nw', 'nwjs.app', 'nwjs.exe'].indexOf(destFile) !== -1){
+                if(['nw', 'nwjs.app', 'nw.exe'].indexOf(destFile) !== -1){
                     // ignore nwjs.app/Contents/Resources/*.lproj, otherwise the app name will show as nwjs.app in
                     // Finder
                     if(destFile === 'nwjs.app'){

--- a/lib/index.js
+++ b/lib/index.js
@@ -380,11 +380,21 @@ NwBuilder.prototype.copyNwjs = function () {
 
             totalFiles.forEach(function(file){
                 var destFile = path.relative(platform.cache, file);
+                var options = {};
 
                 if(['nwjs', 'nwjs.app', 'nwjs.exe'].indexOf(destFile) !== -1){
+                    // ignore nwjs.app/Contents/Resources/*.lproj, otherwise the app name will show as nwjs.app in
+                    // Finder
+                    if(destFile === 'nwjs.app'){
+                        options.filter = function(filepath){
+                            return !/nwjs\.app\/Contents\/Resources\/[^.]+\.lproj(\/|$)/.test(filepath);
+                        };
+                    }
+                    // rename executable to app name
                     destFile = self.options.appName + path.extname(destFile);
                 }
-                copiedFiles.push(Utils.copyFile(file, path.join(platform.releasePath, destFile), self));
+
+                copiedFiles.push(Utils.copyFile(file, path.join(platform.releasePath, destFile), self, options));
                 platform.files.push(destFile);
             });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var inherits = require('inherits');
 var EventEmitter = require('events').EventEmitter;
 var fs = require('graceful-fs-extra');
+var recursiveReaddirSync = require('recursive-readdir-sync');
 var path = require('path');
 var url = require('url');
 var winresourcer = Promise.promisify(require('winresourcer'));
@@ -55,9 +56,8 @@ function NwBuilder(options) {
             options.platforms.splice(options.platforms.indexOf('linux'), 1, 'linux32', 'linux64');
         }
     }
-    // Assing options
+    // Assign options
     this.options = _.defaults(options, defaults);
-    this._platforms = platforms;
 
     // Some Option checking
     if(!this.options.files) {
@@ -71,7 +71,7 @@ function NwBuilder(options) {
     // this + previous check assures as we have only buildable platforms specified
     this.options.platforms.forEach(function(platform) {
         if (!(platform in platforms))
-            throw new Error('unknown platform ' + platform);
+            throw new Error('Unknown platform ' + platform);
     });
 
     this._platforms = _.cloneDeep(platforms);
@@ -87,15 +87,15 @@ NwBuilder.prototype.build = function (callback) {
     var hasCallback = (typeof callback === 'function'),
         done = Promise.defer();
 
-    // Let's create a node Webkit app
+    // Let's create a NWjs app
     this.checkFiles().bind(this)
         .then(this.resolveLatestVersion)
         .then(this.checkVersion)
         .then(this.platformFilesForVersion)
-        .then(this.downloadNodeWebkit)
+        .then(this.downloadNwjs)
         .then(this.preparePlatformSpecificManifests)
         .then(this.createReleaseFolder)
-        .then(this.copyNodeWebkit)
+        .then(this.copyNwjs)
         .then(this.handleMacApp)
         .then(this.handleWinApp)
         .then(this.zipAppFiles)
@@ -125,12 +125,12 @@ NwBuilder.prototype.run = function (callback) {
     var hasCallback = (typeof callback === 'function'),
         done = Promise.defer();
 
-    // Let's run this node Webkit app
+    // Let's run this NWjs app
     this.checkFiles().bind(this)
         .then(this.resolveLatestVersion)
         .then(this.checkVersion)
         .then(this.platformFilesForVersion)
-        .then(this.downloadNodeWebkit)
+        .then(this.downloadNwjs)
         .then(this.runApp)
         .then(function (info) {
             if(hasCallback) {
@@ -177,55 +177,71 @@ NwBuilder.prototype.resolveLatestVersion = function () {
     if(self.options.version !== 'latest') return Promise.resolve();
 
     return NwVersions.getLatestVersion(self.options.downloadUrl).then(function(latestVersion){
-        self.emit('log', 'Latest Version: v' + latestVersion);
-        self.options.version = latestVersion;
+        self.emit('log', 'Latest Version: v' + latestVersion.version);
+        self.options.version = latestVersion.version;
+        return latestVersion;
     });
 };
 
 NwBuilder.prototype.checkVersion = function () {
-    var version = this.options.version.replace('v', '');
+    var version = this.options.version,
+        self = this;
 
-    if(!semver.valid(this.options.version)){
-        return Promise.reject('The version ' + this.options.version + ' is not valid.');
-    } else {
-        this._version = NwVersions.getVersionNames( version );
-        this.emit('log', 'Using v' + this._version.version);
+    if(!semver.valid(version)){
+        return Promise.reject('The version ' + version + ' is not valid.');
     }
 
-    return Promise.resolve();
+    return NwVersions.getVersion({
+        desiredVersion: version,
+        downloadUrl: self.options.downloadUrl
+    })
+    .then(function(version){
+        self._version = version;
+        self.emit('log', 'Using v' + self._version.version);
+    });
 };
 
 NwBuilder.prototype.platformFilesForVersion = function () {
     var self = this;
 
-    this._forEachPlatform(function (name, platform) {
-
-        var satisfied = !Object.keys(platform.files).every(function(range) {
-            if (semver.satisfies(self._version.version, range)) {
-                platform.files = platform.files[range];
-                if('string' === typeof platform.files){
-                    platform.files = [platform.files];
+    if(self._version.isLegacy) {
+        this._forEachPlatform(function (name, platform) {
+            var satisfied = !Object.keys(platform.files).every(function (range) {
+                if (semver.satisfies(self._version.version, range)) {
+                    platform.files = platform.files[range];
+                    if ('string' === typeof platform.files) {
+                        platform.files = [platform.files];
+                    }
+                    return false;
                 }
-                return false;
+                return true;
+            });
+
+            if (!satisfied) {
+                throw new Error("Unsupported NW.js version '" + self._version.version + "' for platform '" + platform.type + "'");
             }
-            return true;
         });
 
-        if (!satisfied) {
-            throw new Error("Unsupported NW.js version '" + self._version.version + "' for platform '" + platform.type + "'");
+        return true;
+    }
+
+    self._forEachPlatform(function (name, platform) {
+        if(!self._version.platforms[name]){
+            throw new Error("Unsupported NW.js version '" + self._version.version + "' for platform '" + name + "'");
         }
+        platform.files = ['*']; // TODO: make this work
     });
 
     return true;
 };
 
-NwBuilder.prototype.downloadNodeWebkit = function () {
+NwBuilder.prototype.downloadNwjs = function () {
     var self = this,
         downloads = [];
 
     this._forEachPlatform(function (name, platform) {
         platform.cache = path.resolve(self.options.cacheDir, self._version.version, name);
-        platform.url = url.resolve(self.options.downloadUrl, self._version.platforms[name]);
+        platform.url = self._version.platforms[name];
 
         // Ensure that there is a cache folder
         if(self.options.forceDownload) {
@@ -245,7 +261,7 @@ NwBuilder.prototype.downloadNodeWebkit = function () {
                             self.emit('log', err.msg);
                         }
 
-                        return Promise.reject('Unable to download nodewebkit.');
+                        return Promise.reject('Unable to download NWjs.');
                     })
             );
             self.emit('log', 'Downloading: ' + platform.url);
@@ -340,11 +356,42 @@ NwBuilder.prototype.createReleaseFolder = function () {
     return Promise.all(directoryCreationPromises);
 };
 
-NwBuilder.prototype.copyNodeWebkit = function () {
+NwBuilder.prototype.copyNwjs = function () {
     var self = this,
         copiedFiles = [];
 
     this._forEachPlatform(function (name, platform) {
+        // >= v0.12.3
+        // Since we only have `*`, we're going to recursively get all the files, then copy them
+        // Since a .app is treated like a directory, we need to ignore files inside them and just copy them entirely
+        if(platform.files.length === 1 && platform.files[0] === '*'){
+            // convert all paths inside a .app, etc. to just point to the .app
+            // then remove duplicates
+            var files = recursiveReaddirSync(platform.cache).map(function(file){
+                var matches = file.match(/^(.+?(\.app|\.framework))/);
+                if(matches){
+                    return matches[1];
+                }
+                return file;
+            });
+
+            var totalFiles = _.uniq(files);
+            platform.files = totalFiles;
+
+            totalFiles.forEach(function(file){
+                var destFile = path.relative(platform.cache, file);
+
+                if(['nwjs', 'nwjs.app', 'nwjs.exe'].indexOf(destFile) !== -1){
+                    destFile = self.options.appName + path.extname(destFile);
+                }
+                copiedFiles.push(Utils.copyFile(file, path.join(platform.releasePath, destFile), self));
+                platform.files.push(destFile);
+            });
+
+            return;
+        }
+
+        // legacy
         platform.files.forEach(function (file, i) {
             var destFile = file;
             if(i===0) {
@@ -378,24 +425,26 @@ NwBuilder.prototype.zipAppFiles = function () {
     var self = this;
 
     // Check if zip is needed
-    var _needsZip = false,
+    var doAnyNeedZip = false,
         numberOfPlatformsWithoutOverrides = 0;
 
     self._zips = {};
 
     this._forEachPlatform(function(name, platform) {
-        _needsZip = self.isPlatformNeedingZip(name, platform);
+        var needsZip = self.isPlatformNeedingZip(name, platform);
 
-        if(_needsZip) {
+        if(needsZip) {
             var platformSpecific = !!platform.platformSpecificManifest;
 
             self._zips[name] = { platformSpecific: platformSpecific };
 
             numberOfPlatformsWithoutOverrides += !platformSpecific;
         }
+
+        doAnyNeedZip = doAnyNeedZip || needsZip;
     });
 
-    self._needsZip = _needsZip;
+    self._needsZip = doAnyNeedZip;
 
     return new Promise(function(resolve, reject) {
 
@@ -441,10 +490,9 @@ NwBuilder.prototype.zipAppFiles = function () {
 };
 
 NwBuilder.prototype.mergeAppFiles = function () {
-    var self = this,
-        copiedFiles = [];
+    var self = this;
 
-    var copyPromise = Promise.resolve();
+    var copyPromises = [];
 
     this._forEachPlatform(function (name, platform) {
         var zipping = self.isPlatformNeedingZip(name, platform);
@@ -461,30 +509,30 @@ NwBuilder.prototype.mergeAppFiles = function () {
                 }
 
                 if(file.dest === 'package.json' && platform.platformSpecificManifest){
-                    copyPromise = copyPromise.then(function(){ return self.writePlatformSpecificManifest(platform, dest) } );
+                    copyPromises.push(self.writePlatformSpecificManifest(platform, dest));
                 }
                 else {
-                    copyPromise = copyPromise.then(function(){ return Utils.copyFile(file.src, dest, self) });
+                    copyPromises.push(Utils.copyFile(file.src, dest, self));
                 }
             });
         } else if(name == 'osx32' || name == 'osx64') {
             // zip just copy the app.nw
-            copyPromise = copyPromise.then(function(){ return Utils.copyFile(
+            copyPromises.push(Utils.copyFile(
                 self.getZipFile(name),
                 path.resolve(self.getResourcesDirectoryPath(platform), 'app.nw'),
                 self
-            ) });
+            ));
         } else {
             // We cat the app.nw file into the .exe / nw
-            copyPromise = copyPromise.then(function(){ return Utils.mergeFiles(
-                path.resolve(platform.releasePath, _.first(platform.files)),
+            copyPromises.push(Utils.mergeFiles(
+                path.resolve(platform.releasePath, _.first(platform.files)), // TODO: maybe not safe with new versions
                 self.getZipFile(name),
                 platform.chmod
-            )});
+            ));
         }
     });
 
-    return copyPromise;
+    return Promise.all(copyPromises);
 };
 
 NwBuilder.prototype.getZipFile = function(platformName){

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,6 @@ NwBuilder.prototype.checkVersion = function () {
                 areAllPlatformsCached = false;
             }
         });
-        console.log('+++ areAllPlatformsCached', areAllPlatformsCached)
         if(areAllPlatformsCached){
             getVersion = Promise.resolve(new Version({
                 version: version,
@@ -616,7 +615,13 @@ NwBuilder.prototype.handleMacApp = function () {
 
         // Let's first handle the mac icon
         if(self.options.macIcns) {
-            allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(self.getResourcesDirectoryPath(platform), 'nw.icns'), self));
+            if(self._version.isLegacy) {
+                allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(self.getResourcesDirectoryPath(platform), 'nw.icns'), self));
+            }
+            else {
+                allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(self.getResourcesDirectoryPath(platform), 'app.icns'), self));
+                allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(self.getResourcesDirectoryPath(platform), 'document.icns'), self));
+            }
         }
 
         // Handle mac credits

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var deprecate = require('deprecate');
 var detectCurrentPlatform = require('./detectCurrentPlatform.js');
 
 var NwVersions = require('./versions');
+var Version = require('./Version');
 var Utils = require('./utils');
 var Downloader = require('./downloader');
 var platforms = require('./platforms');
@@ -190,10 +191,51 @@ NwBuilder.prototype.checkVersion = function () {
         return Promise.reject('The version ' + version + ' is not valid.');
     }
 
-    return NwVersions.getVersion({
-        desiredVersion: version,
-        downloadUrl: self.options.downloadUrl
-    })
+
+    var getVersionFromManifest = function(){
+        return NwVersions.getVersion({
+            desiredVersion: version,
+            downloadUrl: self.options.downloadUrl
+        });
+    };
+    var getVersion;
+
+    // if the user specified the exact version and all its platforms are cached, don't hit the manifest at all;
+    // just trust the ones are cached and assume they're supported
+    if(self.options.version !== 'latest'){
+        var areAllPlatformsCached = true;
+        this._forEachPlatform(function(name, platform){
+            var platformToCheck = platform;
+
+            if(semver.satisfies(self.options.version, '>=0.12.3')) {
+                platformToCheck = _.clone(platform);
+                platformToCheck.files = ['*']; // otherwise it'll try to check cache legacy version files
+            }
+
+            if(!self.isPlatformCached(name, platformToCheck, self.options.version)){
+                areAllPlatformsCached = false;
+            }
+        });
+        console.log('+++ areAllPlatformsCached', areAllPlatformsCached)
+        if(areAllPlatformsCached){
+            getVersion = Promise.resolve(new Version({
+                version: version,
+                downloadUrl: self.options.downloadUrl,
+                supportedPlatforms: Object.keys(this._platforms)
+            }));
+        }
+        else {
+            // otherwise hit the manifest
+            getVersion = getVersionFromManifest();
+        }
+    }
+    else {
+        // otherwise hit the manifest
+        getVersion = getVersionFromManifest();
+    }
+
+
+    return getVersion
     .then(function(version){
         self._version = version;
         self.emit('log', 'Using v' + self._version.version);
@@ -242,7 +284,7 @@ NwBuilder.prototype.downloadNwjs = function () {
         downloads = [];
 
     this._forEachPlatform(function (name, platform) {
-        platform.cache = path.resolve(self.options.cacheDir, self._version.version, name);
+        self.setPlatformCacheDirectory(name, platform, self._version.version);
         platform.url = self._version.platforms[name];
 
         // Ensure that there is a cache folder
@@ -253,7 +295,7 @@ NwBuilder.prototype.downloadNwjs = function () {
         fs.mkdirpSync(platform.cache);
         self.emit('log', 'Create cache folder in ' + path.resolve(self.options.cacheDir, self._version.version));
 
-        if(!Downloader.checkCache(platform.cache, platform.files)) {
+        if(!self.isPlatformCached(name, platform, self._version.version)) {
             downloads.push(
                 Downloader.downloadAndUnpack(platform.cache, platform.url)
                     .catch(function(err){
@@ -706,4 +748,19 @@ NwBuilder.prototype.getExecutableName = function (platform) {
     }
 
     return this.options.appName + executableExtension;
+};
+
+NwBuilder.prototype.setPlatformCacheDirectory = function (platformName, platform, version) {
+    if(!platform.cache) {
+        platform.cache = path.resolve(this.options.cacheDir, version, platformName);
+    }
+};
+
+
+NwBuilder.prototype.isPlatformCached = function (platformName, platform, version) {
+    this.setPlatformCacheDirectory(platformName, platform, version);
+    if (this.options.forceDownload) {
+        return false;
+    }
+    return Downloader.checkCache(platform.cache, platform.files);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -538,14 +538,16 @@ NwBuilder.prototype.mergeAppFiles = function () {
                 executableToMergeWith = _.first(platform.files);
             }
             else {
-                executableToMergeWith  = 'nw';
+                var executableExtension = '';
 
                 if(name.indexOf('osx') === 0){
-                    executableToMergeWith += '.app';
+                    executableExtension = '.app';
                 }
                 else if(name.indexOf('win') === 0){
-                    executableToMergeWith += '.exe';
+                    executableExtension = '.exe';
                 }
+
+                executableToMergeWith = self.options.appName + executableExtension;
             }
 
             // We cat the app.nw file into the .exe / nw

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,6 @@ var platforms = require('./platforms');
 inherits(NwBuilder, EventEmitter);
 module.exports = NwBuilder;
 function NwBuilder(options) {
-    var self = this;
     var defaults = {
         files: null,
         appName: false,
@@ -229,7 +228,7 @@ NwBuilder.prototype.platformFilesForVersion = function () {
         if(!self._version.platforms[name]){
             throw new Error("Unsupported NW.js version '" + self._version.version + "' for platform '" + name + "'");
         }
-        platform.files = ['*']; // TODO: make this work
+        platform.files = ['*'];
     });
 
     return true;
@@ -382,7 +381,7 @@ NwBuilder.prototype.copyNwjs = function () {
                 var destFile = path.relative(platform.cache, file);
                 var options = {};
 
-                if(['nwjs', 'nwjs.app', 'nwjs.exe'].indexOf(destFile) !== -1){
+                if(['nw', 'nwjs.app', 'nwjs.exe'].indexOf(destFile) !== -1){
                     // ignore nwjs.app/Contents/Resources/*.lproj, otherwise the app name will show as nwjs.app in
                     // Finder
                     if(destFile === 'nwjs.app'){
@@ -429,7 +428,7 @@ NwBuilder.prototype.isPlatformNeedingZip = function(name, platform) {
     }
 
     return needsZip;
-}
+};
 
 NwBuilder.prototype.zipAppFiles = function () {
     var self = this;
@@ -533,9 +532,25 @@ NwBuilder.prototype.mergeAppFiles = function () {
                 self
             ));
         } else {
+            var executableToMergeWith;
+
+            if(self._version.isLegacy){
+                executableToMergeWith = _.first(platform.files);
+            }
+            else {
+                executableToMergeWith  = 'nw';
+
+                if(name.indexOf('osx') === 0){
+                    executableToMergeWith += '.app';
+                }
+                else if(name.indexOf('win') === 0){
+                    executableToMergeWith += '.exe';
+                }
+            }
+
             // We cat the app.nw file into the .exe / nw
             copyPromises.push(Utils.mergeFiles(
-                path.resolve(platform.releasePath, _.first(platform.files)), // TODO: maybe not safe with new versions
+                path.resolve(platform.releasePath, executableToMergeWith),
                 self.getZipFile(name),
                 platform.chmod
             ));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,10 +81,11 @@ module.exports = {
     pathDepth: function(absolutePath) {
         return absolutePath.split(path.sep).length;
     },
-    copyFile: function (src, dest, _event) {
+    copyFile: function (src, dest, _event, options) {
         return new Promise(function(resolve, reject) {
+            options = options || {};
             var stats = fs.lstatSync(src);
-            fs.copy(src, dest, function (err) {
+            fs.copy(src, dest, options, function (err) {
                 if(err) return reject(err);
 
                 var retryCount = 0;

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -113,7 +113,8 @@ function getVersionsFromManifest(downloadUrl){
     return getManifest().then(function(manifest){
         return manifest.versions
             .filter(function(versionFromManifest){
-                return versionFromManifest.flavors.indexOf('sdk') !== -1;
+                // 0.12.3 is an exception that is in the manifest but is kind of a legacy version
+                return versionFromManifest.flavors.indexOf('sdk') !== -1 || versionFromManifest.version === 'v0.12.3';
             })
             .map(function(versionFromManifest){
                 return new Version({

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -5,6 +5,11 @@ var request = require('request');
 var _ = require('lodash');
 var Version = require('./Version');
 
+/**
+ * @param {string} url
+ * @param {object} options - Passed to request
+ * @returns {promise} which resolves to response body
+ */
 function get(url, options){
     var deferred = Promise.defer();
 
@@ -21,6 +26,10 @@ function get(url, options){
     return deferred.promise;
 }
 
+/**
+ * @param {string} downloadUrl
+ * @returns {promise} which resolves to an array of {Version}s
+ */
 function getLegacyVersions(downloadUrl){
     var scrapePtrn = /href="v?([0-9]+\.[0-9]+\.[0-9]+[^"]*)\/"/ig,
         searchRes,
@@ -80,12 +89,19 @@ function getLegacyVersions(downloadUrl){
     });
 }
 
+/**
+ * @returns {promise} which resolves to response body
+ */
 function getManifest(){
     return get('http://nwjs.io/versions.json', { json: true }).then(function(body){
         return body;
     });
 }
 
+/**
+ * @param {string} downloadUrl
+ * @returns {promise} which resolves to an array of {Version}s
+ */
 function getVersionsFromManifest(downloadUrl){
     var mapFilesToPlatforms = function(files){
         return files.map(function(file){
@@ -109,12 +125,20 @@ function getVersionsFromManifest(downloadUrl){
     });
 }
 
+/**
+ * @param {string} version
+ * @returns {boolean}
+ */
 function isLegacyVersion(version){
     return semver.satisfies(version, '<0.12.3');
 }
 
 module.exports = {
-    // Gets the latest stable version
+    /**
+     * Gets the latest stable version
+     * @param {string} downloadUrl
+     * @returns {promise} which resolves to a {Version}
+     */
     getLatestVersion: function(downloadUrl) {
         return getManifest()
             .then(function(manifest) {
@@ -125,7 +149,11 @@ module.exports = {
             })
             .then(this.getVersion);
     },
-    // TODO js doc
+    /**
+     * @param {string} args.desiredVersion
+     * @param {string} args.downloadUrl
+     * @returns {promise} which resolves to a {Version}
+     */
     getVersion: function(args){
         return (isLegacyVersion(args.desiredVersion) ? getLegacyVersions : getVersionsFromManifest)(args.downloadUrl)
             .then(function(versions) {
@@ -141,6 +169,10 @@ module.exports = {
                 throw new Error('Version ' + args.desiredVersion + ' not found.');
             });
     },
+    /**
+     * @param {string} downloadUrl
+     * @returns {promise} which resolves to an array of {Version}s
+     */
     getVersions: function(downloadUrl){
         return Promise.all([getVersionsFromManifest(downloadUrl), getLegacyVersions(downloadUrl)])
             .then(function(versionLists){

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,86 +1,150 @@
 var Promise = require('bluebird');
+var platforms = require('./platforms');
 var semver = require('semver');
-var platforms = require('./platforms.js');
 var request = require('request');
 var _ = require('lodash');
-var resolveUrl = require('url').resolve;
+var Version = require('./Version');
 
-function getVersionList(url){
-    var done = Promise.defer(),
-        scrapePtrn = /href="v?([0-9]+\.[0-9]+\.[0-9]+[^"]*)\/"/ig,
-        searchRes,
-        versions = [];
+function get(url, options){
+    var deferred = Promise.defer();
 
-    request(url, function (err, res, body) {
+    request(url, options, function (err, res, body) {
         if (err) {
-            done.reject(err);
+            deferred.reject(err);
         } else if (res.statusCode !== 200) {
-            done.reject('Received status code '+res.statusCode+' when checking for available versions.');
+            deferred.reject('Received status code ' + res.statusCode + ': ' + url);
         } else {
-            // scrapes valid semver versions from apache directory listing
-            while ((searchRes = scrapePtrn.exec(body)) !== null) {
-                searchRes = searchRes[1];
-                if( semver.valid(searchRes) && !_.contains(versions, searchRes) ) {
-                    versions.push(searchRes);
-                }
-            }
-            // order with newest version at front of array
-            versions = versions.sort(function(a,b){ return semver.compare(b,a); });
-
-            // filter out invalid / alpha versions
-            var validationPromises = [];
-            versions.forEach(function(version){
-                validationPromises.push(new Promise(function(resolve, reject){
-                    // check if windows 64-bit ZIP exists
-                    request.head(resolveUrl(url, module.exports.getVersionNames(version).platforms.win32), function(err, res){
-                        // note: this takes a version string and replaces it with an object (will be converted back later)
-                        resolve({
-                            version: version,
-                            valid: !err && res.statusCode === 200
-                        });
-                    });
-                }));
-            });
-
-            Promise.all(validationPromises)
-                .then(function(versions){
-                    // convert back to array of version strings (filtered)
-                    versions = versions.filter(function(versionObj){ return versionObj.valid; })
-                        .map(function(versionObj){ return versionObj.version; });
-                    done.resolve(versions);
-                }, done.reject);
+            deferred.resolve(body);
         }
     });
 
-    return done.promise;
+    return deferred.promise;
+}
+
+function getLegacyVersions(downloadUrl){
+    var scrapePtrn = /href="v?([0-9]+\.[0-9]+\.[0-9]+[^"]*)\/"/ig,
+        searchRes,
+        versions = [];
+
+    return get(downloadUrl).then(function(body){
+        // scrapes valid semver versions from apache directory listing
+        while ((searchRes = scrapePtrn.exec(body)) !== null) {
+            searchRes = searchRes[1];
+            if( semver.valid(searchRes) && !_.contains(versions, searchRes) ) {
+                versions.push(searchRes);
+            }
+        }
+        // order with newest version at front of array
+        versions = versions.sort(function(a,b){ return semver.compare(b,a); });
+
+        // filter out invalid / alpha versions
+        var validationPromises = [];
+        versions.forEach(function(version){
+            if(!isLegacyVersion(version)){
+                return;
+            }
+            validationPromises.push(new Promise(function(resolve, reject){
+                // check if windows 64-bit ZIP exists
+                var win32Url = new Version({
+                    version: version,
+                    supportedPlatforms: ['win32'],
+                    downloadUrl: downloadUrl
+                }).platforms.win32;
+                request.head(win32Url, function(err, res){
+                    // note: this takes a version string and replaces it with an object (will be converted back later)
+                    resolve({
+                        version: version,
+                        valid: !err && res.statusCode === 200
+                    });
+                });
+
+            }));
+        });
+
+        var allPlatforms = Object.keys(platforms);
+
+        return Promise.all(validationPromises)
+            .then(function(versions){
+                // convert back to array of version strings (filtered)
+                return versions.filter(function(versionObj){
+                        return versionObj.valid;
+                    })
+                    .map(function(versionObj){
+                        return new Version({
+                            version: versionObj.version,
+                            supportedPlatforms: allPlatforms,
+                            downloadUrl: downloadUrl
+                        });
+                    });
+            });
+    });
+}
+
+function getManifest(){
+    return get('http://nwjs.io/versions.json', { json: true }).then(function(body){
+        return body;
+    });
+}
+
+function getVersionsFromManifest(downloadUrl){
+    var mapFilesToPlatforms = function(files){
+        return files.map(function(file){
+            // convert win-x64 to win64, linux-ia32 to linux 32, etc.
+            return file.replace(/-(x|ia)/, '');
+        });
+    };
+
+    return getManifest().then(function(manifest){
+        return manifest.versions
+            .filter(function(versionFromManifest){
+                return versionFromManifest.flavors.indexOf('sdk') !== -1;
+            })
+            .map(function(versionFromManifest){
+                return new Version({
+                    version: versionFromManifest.version.replace('v', ''),
+                    supportedPlatforms: mapFilesToPlatforms(versionFromManifest.files),
+                    downloadUrl: downloadUrl
+                });
+            });
+    });
+}
+
+function isLegacyVersion(version){
+    return semver.satisfies(version, '<0.12.3');
 }
 
 module.exports = {
-    getLatestVersion: function(url) {
-        return getVersionList(url)
+    // Gets the latest stable version
+    getLatestVersion: function(downloadUrl) {
+        return getManifest()
+            .then(function(manifest) {
+                return {
+                    desiredVersion: manifest.stable.replace('v', ''),
+                    downloadUrl: downloadUrl
+                }
+            })
+            .then(this.getVersion);
+    },
+    // TODO js doc
+    getVersion: function(args){
+        return (isLegacyVersion(args.desiredVersion) ? getLegacyVersions : getVersionsFromManifest)(args.downloadUrl)
             .then(function(versions) {
-                return versions[0];
+                var version = versions.find(function(version){
+                    if(version.version === args.desiredVersion) {
+                        return version;
+                    }
+                });
+
+                if(version){
+                    return version;
+                }
+                throw new Error('Version ' + args.desiredVersion + ' not found.');
             });
     },
-    getVersions: function (url) {
-        return getVersionList(url);
-    },
-    getVersionNames: function (v) {
-        var versionNames = {
-            version: v,
-            platforms: {}
-        };
-
-        var templateData = {
-            version: v,
-            name: semver.satisfies(v, '>=0.12.0 || ~0.12.0-alpha') ? 'nwjs' : 'node-webkit'
-        };
-
-        // create a hash of platform version names based on current platforms
-        _.forEach(platforms, function (platform, name) {
-            versionNames.platforms[name] = _.template(platform.versionNameTemplate, templateData);
-        });
-
-        return versionNames;
+    getVersions: function(downloadUrl){
+        return Promise.all([getVersionsFromManifest(downloadUrl), getLegacyVersions(downloadUrl)])
+            .then(function(versionLists){
+                return versionLists[0].concat(versionLists[1]);
+            });
     }
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "nw-builder",
   "main": "index.js",
   "scripts": {
-    "test": "colortape test/*.js"
+    "test": "colortape test/*.js",
+    "test-plain": "tape test/*.js"
   },
   "repository": {
     "type": "git",
@@ -48,7 +49,8 @@
     "plist": "^1.0.0",
     "progress": "~1.1.7",
     "rcedit": "^0.5.0",
-    "request": "^2.40.0",
+    "recursive-readdir-sync": "^1.0.6",
+    "request": "~2.40.0",
     "rimraf": "^2.5.2",
     "semver": "^2.3.1",
     "simple-glob": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bluebird": "^3.4.0",
     "decompress-zip": "0.3.0",
     "deprecate": "~0.1.0",
-    "graceful-fs-extra": "^1.0.4",
+    "graceful-fs-extra": "^1.1.0",
     "graceful-ncp": "^3.0.0",
     "inherits": "~2.0.1",
     "lodash": "~2.4.1",

--- a/test/fixtures/manifest/versions.json
+++ b/test/fixtures/manifest/versions.json
@@ -1,0 +1,23 @@
+
+{
+  "latest": "v0.16.0-beta1",
+  "stable": "v0.15.2",
+  "lts": "v0.14.6",
+  "versions": [
+    {
+      "version": "v0.15.2",
+      "files": ["win-x64", "win-ia32", "linux-x64", "linux-ia32", "osx-x64"],
+      "flavors": ["normal", "sdk"]
+    },
+    {
+      "version": "v0.13.2",
+      "files": ["win-x64", "linux-ia32", "osx-x64"],
+      "flavors": ["normal", "sdk", "nacl"]
+    },
+    {
+      "version": "v0.12.3",
+      "files": ["win-x64", "win-ia32", "linux-x64", "linux-ia32", "osx-x64", "osx-ia32"],
+      "flavors": ["normal", "macappstore"]
+    }
+  ]
+}

--- a/test/fixtures/testVersions.html
+++ b/test/fixtures/testVersions.html
@@ -10,8 +10,6 @@
 <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="live-build/">live-build/</a></td><td align="right">13-Aug-2014 02:45  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="v0.9.3/">v0.9.3/</a></td><td align="right">22-May-2014 06:16  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="v0.10.0-rc1/">v0.10.0-rc1/</a></td><td align="right">22-Jun-2014 04:16  </td><td align="right">  - </td><td>&nbsp;</td></tr>
-<tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="v0.10.0/">v0.10.0/</a></td><td align="right">22-Jul-2014 01:40  </td><td align="right">  - </td><td>&nbsp;</td></tr>
-<tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="v0.10.1/">v0.10.1/</a></td><td align="right">30-Jul-2014 05:43  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="v0.10.2/">v0.10.2/</a></td><td align="right">12-Aug-2014 06:13  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><th colspan="5"><hr></th></tr>
 </table>

--- a/test/nwBuilder.js
+++ b/test/nwBuilder.js
@@ -12,223 +12,226 @@ var xmlFixture = '<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns=
 var baseUrl = 'https://amazon.s3.nw.com';
 nock(baseUrl).get('/xml').reply(200, xmlFixture);
 
-//test('Throw files', function (t) {
-//    t.plan(1);
-//    t.throws(function() {
-//        new NwBuilder({'files':null});
-//    }, 'Check for files');
-//});
-//
-//test('Throw platforms', function (t) {
-//    t.plan(1);
-//    t.throws(function () {
-//        new NwBuilder({'platforms':null});
-//    }, 'Check for platforms');
-//});
-//
-//
-//test('Should check if we have some files', function (t) {
-//    t.plan(2);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/nwapp/**/*'
-//    });
-//
-//    x.checkFiles().then(function (data) {
-//        t.deepEqual(x._appPkg, {"name":"nw-demo","version":"0.1.0","main":"index.html"});
-//        t.equal(x._files.length, 6);
-//    });
-//});
-//
-//
-//test('Should take the option name if provided', function (t) {
-//    t.plan(1);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/nwapp/**/*',
-//        appName: 'somename'
-//    });
-//
-//    x.checkFiles().then(function (data) {
-//        t.equal(x.options.appName, 'somename');
-//    });
-//});
-//
-//test('Should check if we have some files: rejection', function (t) {
-//    t.plan(1);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/nwapp/images/**'
-//    });
-//
-//    x.checkFiles().catch(function (error) {
-//        t.equal(error, 'Could not find a package.json in your src folder');
-//    });
-//
-//});
-//
-//test('Should apply platform-specific overrides correctly', function (t) {
-//    t.plan(6);
-//
-//    var x = new NwBuilder({
-//            files: './test/fixtures/platformOverrides/**/*',
-//            platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64']
-//        });
-//
-//    x.checkFiles().bind(x)
-//    .then(x.preparePlatformSpecificManifests)
-//    .then(function () {
-//        _.forEach(x._platforms, function(platform, platformName){
-//            var file = fs.readFileSync(path.join('./test/expected/platformOverrides', platformName + '.json'));
-//            t.deepEqual(platform.platformSpecificManifest, JSON.parse(file.toString()), platformName + '.json');
-//        });
-//    });
-//});
-//
-//test('Should only create one ZIP if there are no platform-specific overrides', function (t) {
-//    t.plan(17);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/nwapp/**/*',
-//        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
-//        macZip: true
-//    });
-//
-//    x.checkFiles().bind(x)
-//        .then(x.preparePlatformSpecificManifests)
-//        .then(x.zipAppFiles)
-//        .then(function () {
-//            _.forEach(x._zips, function(zip, platformName){
-//                t.equal(zip.platformSpecific, false, platformName + ' should be marked as platform specific');
-//                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
-//            });
-//
-//            t.deepEqual(x._zips.osx32, x._zips.osx64, 'OSX 32-bit ZIP should be equal to the OSX 64-bit one');
-//            t.deepEqual(x._zips.osx64, x._zips.win32, 'OSX 64-bit ZIP should be equal to the Windows 32-bit one');
-//            t.deepEqual(x._zips.win32, x._zips.win64, 'Windows 32-bit ZIP should be equal to the Windows 64-bit one');
-//            t.deepEqual(x._zips.win64, x._zips.linux32, 'Windows 64-bit ZIP should be equal to the Linux 32-bit one');
-//            t.deepEqual(x._zips.linux32, x._zips.linux64, 'Linux 32-bit ZIP should be equal to the Linux 64-bit one');
-//        });
-//});
-//
-//test('Should create a ZIP per platform if every platform has overrides', function (t) {
-//    t.plan(15);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/platformOverrides/**/*',
-//        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
-//        macZip: true
-//    });
-//
-//    x.checkFiles().bind(x)
-//        .then(x.preparePlatformSpecificManifests)
-//        .then(x.zipAppFiles)
-//        .then(function () {
-//            _.forEach(x._zips, function(zip, platformName){
-//                t.equal(zip.platformSpecific, true, platformName + ' should be marked as platform specific');
-//                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
-//            });
-//
-//            t.notDeepEqual(x._zips.osx32, x._zips.win32, "OSX ZIP should be different to the Windows one");
-//            t.notDeepEqual(x._zips.win32, x._zips.linux32, "Windows ZIP should be different to the Linux 32 one");
-//            t.notDeepEqual(x._zips.linux32, x._zips.linux64, "Linux 32 ZIP should be different to the Linux 64 one");
-//        });
-//});
-//
-//test('Should create a ZIP per platform which has overrides and one between the rest', function (t) {
-//    t.plan(15);
-//
-//    var x = new NwBuilder({
-//        files: './test/fixtures/oneOveriddenRestNot/**/*',
-//        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
-//        macZip: true
-//    });
-//
-//    x.checkFiles().bind(x)
-//        .then(x.preparePlatformSpecificManifests)
-//        .then(x.zipAppFiles)
-//        .then(function () {
-//            _.forEach(x._zips, function(zip, platformName){
-//                t.equal(zip.platformSpecific, platformName === 'osx32', platformName + ' should be marked as platform specific');
-//                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
-//            });
-//
-//            t.notDeepEqual(x._zips.osx32, x._zips.win32, "OSX ZIP should be different to the Windows one");
-//            t.deepEqual(x._zips.win32, x._zips.linux32, "Windows ZIP should be equal to the Linux 32 one");
-//            t.deepEqual(x._zips.linux32, x._zips.linux64, "Linux 32 ZIP should be equal to the Linux 64 one");
-//        });
-//});
-//
-//test('Should find latest version', function (t) {
-//    t.plan(2);
-//
-//    var x = new NwBuilder({
-//        files: '**',
-//        version: 'latest'
-//    });
-//
-//    x.resolveLatestVersion().then(function (data) {
-//    	t.ok(semver.valid(x.options.version), 'Version: ' + x.options.version);
-//    });
-//
-//    x.on('log', function (message) {
-//    	t.equal(/Latest Version: v*/.test(message), true, 'should log version');
-//    });
-//
-//});
-//
-//test('Should not accept an invalid version', function (t) {
-//    t.plan(1);
-//
-//    var x = new NwBuilder({
-//        files: '**',
-//        version: '1.blah.0'
-//    });
-//
-//    x.checkVersion().catch(function(err) {
-//      	t.ok(err);
-//    });
-//
-//});
-//
-//test('Should not zip mac apps by default', function (t) {
-//    t.plan(1);
-//
-//    var x = new NwBuilder({ files: './test/fixtures/nwapp/**/*', platforms: ['osx32', 'osx64'] });
-//    x.zipAppFiles().then(function () {
-//        t.notOk(x._needsZip);
-//    });
-//
-//});
-//
-//
-//testSetup({
-//    afterEach: function(done){
-//        del('./test/temp/oneOverridenRestNot', done);
-//    }
-//})('Should write package.json with platform overrides for (unzipped) Mac build', function (t) {
-//    t.plan(1);
-//
-//    var appName = 'theapp',
-//        buildDir = './test/temp/oneOverridenRestNot',
-//        x = new NwBuilder({
-//            files: './test/fixtures/oneOveriddenRestNot/**/*',
-//            platforms: ['osx32'],
-//            appName: appName,
-//            buildDir: buildDir
-//        });
-//
-//    x.checkFiles().bind(x)
-//        .then(x.preparePlatformSpecificManifests)
-//        .then(x.createReleaseFolder)
-//        .then(x.mergeAppFiles)
-//        .then(function () {
-//            t.deepEqual(
-//                JSON.parse(fs.readFileSync(path.join(
-//                    buildDir, appName, 'osx32', appName + '.app', 'Contents', 'Resources', 'app.nw', 'package.json'
-//                )).toString()),
-//                JSON.parse(fs.readFileSync('./test/expected/oneOveriddenRestNot/osx32.json').toString())
-//            );
-//            t.end();
-//        });
-//});
+test('Throw files', function (t) {
+    t.plan(1);
+    t.throws(function() {
+        new NwBuilder({'files':null});
+    }, 'Check for files');
+});
+
+test('Throw platforms', function (t) {
+    t.plan(1);
+    t.throws(function () {
+        new NwBuilder({'platforms':null});
+    }, 'Check for platforms');
+});
+
+
+test('Should check if we have some files', function (t) {
+    t.plan(2);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/nwapp/**/*'
+    });
+
+    x.checkFiles().then(function (data) {
+        t.deepEqual(x._appPkg, {"name":"nw-demo","version":"0.1.0","main":"index.html"});
+        t.equal(x._files.length, 6);
+    });
+});
+
+
+test('Should take the option name if provided', function (t) {
+    t.plan(1);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/nwapp/**/*',
+        appName: 'somename'
+    });
+
+    x.checkFiles().then(function (data) {
+        t.equal(x.options.appName, 'somename');
+    });
+});
+
+test('Should check if we have some files: rejection', function (t) {
+    t.plan(1);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/nwapp/images/**'
+    });
+
+    x.checkFiles().catch(function (error) {
+        t.equal(error, 'Could not find a package.json in your src folder');
+    });
+
+});
+
+test('Should apply platform-specific overrides correctly', function (t) {
+    t.plan(6);
+
+    var x = new NwBuilder({
+            files: './test/fixtures/platformOverrides/**/*',
+            platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64']
+        });
+
+    x.checkFiles().bind(x)
+    .then(x.preparePlatformSpecificManifests)
+    .then(function () {
+        _.forEach(x._platforms, function(platform, platformName){
+            var file = fs.readFileSync(path.join('./test/expected/platformOverrides', platformName + '.json'));
+            t.deepEqual(platform.platformSpecificManifest, JSON.parse(file.toString()), platformName + '.json');
+        });
+    });
+});
+
+test('Should only create one ZIP if there are no platform-specific overrides', function (t) {
+    t.plan(17);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/nwapp/**/*',
+        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
+        macZip: true
+    });
+
+    x.checkFiles().bind(x)
+        .then(x.preparePlatformSpecificManifests)
+        .then(x.zipAppFiles)
+        .then(function () {
+            _.forEach(x._zips, function(zip, platformName){
+                t.equal(zip.platformSpecific, false, platformName + ' should be marked as platform specific');
+                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
+            });
+
+            t.deepEqual(x._zips.osx32, x._zips.osx64, 'OSX 32-bit ZIP should be equal to the OSX 64-bit one');
+            t.deepEqual(x._zips.osx64, x._zips.win32, 'OSX 64-bit ZIP should be equal to the Windows 32-bit one');
+            t.deepEqual(x._zips.win32, x._zips.win64, 'Windows 32-bit ZIP should be equal to the Windows 64-bit one');
+            t.deepEqual(x._zips.win64, x._zips.linux32, 'Windows 64-bit ZIP should be equal to the Linux 32-bit one');
+            t.deepEqual(x._zips.linux32, x._zips.linux64, 'Linux 32-bit ZIP should be equal to the Linux 64-bit one');
+        });
+});
+
+test('Should create a ZIP per platform if every platform has overrides', function (t) {
+    t.plan(15);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/platformOverrides/**/*',
+        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
+        macZip: true
+    });
+
+    x.checkFiles().bind(x)
+        .then(x.preparePlatformSpecificManifests)
+        .then(x.zipAppFiles)
+        .then(function () {
+            _.forEach(x._zips, function(zip, platformName){
+                t.equal(zip.platformSpecific, true, platformName + ' should be marked as platform specific');
+                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
+            });
+
+            t.notDeepEqual(x._zips.osx32, x._zips.win32, "OSX ZIP should be different to the Windows one");
+            t.notDeepEqual(x._zips.win32, x._zips.linux32, "Windows ZIP should be different to the Linux 32 one");
+            t.notDeepEqual(x._zips.linux32, x._zips.linux64, "Linux 32 ZIP should be different to the Linux 64 one");
+        });
+});
+
+test('Should create a ZIP per platform which has overrides and one between the rest', function (t) {
+    t.plan(15);
+
+    var x = new NwBuilder({
+        files: './test/fixtures/oneOveriddenRestNot/**/*',
+        platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
+        macZip: true
+    });
+
+    x.checkFiles().bind(x)
+        .then(x.preparePlatformSpecificManifests)
+        .then(x.zipAppFiles)
+        .then(function () {
+            _.forEach(x._zips, function(zip, platformName){
+                t.equal(zip.platformSpecific, platformName === 'osx32', platformName + ' should be marked as platform specific');
+                t.equal(!!zip.file, true, platformName + " ZIP file property should exist");
+            });
+
+            t.notDeepEqual(x._zips.osx32, x._zips.win32, "OSX ZIP should be different to the Windows one");
+            t.deepEqual(x._zips.win32, x._zips.linux32, "Windows ZIP should be equal to the Linux 32 one");
+            t.deepEqual(x._zips.linux32, x._zips.linux64, "Linux 32 ZIP should be equal to the Linux 64 one");
+        });
+});
+
+test('Should find latest version', function (t) {
+    t.plan(2);
+
+    nock('http://nwjs.io').get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    nock('http://nwjs.io').get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+
+    var x = new NwBuilder({
+        files: '**',
+        version: 'latest'
+    });
+
+    x.resolveLatestVersion().then(function (data) {
+    	t.ok(semver.valid(x.options.version), 'Version: ' + x.options.version);
+    });
+
+    x.on('log', function (message) {
+    	t.equal(/Latest Version: v*/.test(message), true, 'should log version');
+    });
+
+});
+
+test('Should not accept an invalid version', function (t) {
+    t.plan(1);
+
+    var x = new NwBuilder({
+        files: '**',
+        version: '1.blah.0'
+    });
+
+    x.checkVersion().catch(function(err) {
+      	t.ok(err);
+    });
+
+});
+
+test('Should not zip mac apps by default', function (t) {
+    t.plan(1);
+
+    var x = new NwBuilder({ files: './test/fixtures/nwapp/**/*', platforms: ['osx32', 'osx64'] });
+    x.zipAppFiles().then(function () {
+        t.notOk(x._needsZip);
+    });
+
+});
+
+
+testSetup({
+    afterEach: function(done){
+        del('./test/temp/oneOverridenRestNot', done);
+    }
+})('Should write package.json with platform overrides for (unzipped) Mac build', function (t) {
+    t.plan(1);
+
+    var appName = 'theapp',
+        buildDir = './test/temp/oneOverridenRestNot',
+        x = new NwBuilder({
+            files: './test/fixtures/oneOveriddenRestNot/**/*',
+            platforms: ['osx32'],
+            appName: appName,
+            buildDir: buildDir
+        });
+
+    x.checkFiles().bind(x)
+        .then(x.preparePlatformSpecificManifests)
+        .then(x.createReleaseFolder)
+        .then(x.mergeAppFiles)
+        .then(function () {
+            t.deepEqual(
+                JSON.parse(fs.readFileSync(path.join(
+                    buildDir, appName, 'osx32', appName + '.app', 'Contents', 'Resources', 'app.nw', 'package.json'
+                )).toString()),
+                JSON.parse(fs.readFileSync('./test/expected/oneOveriddenRestNot/osx32.json').toString())
+            );
+            t.end();
+        });
+});

--- a/test/versions.js
+++ b/test/versions.js
@@ -4,122 +4,267 @@ var test = require('tape'),
 
 var versions = require('./../lib/versions');
 
-var fixturesVersionsHtml = './test/fixtures/testVersions.html';
-var dlUrl = 'http://dl.node-webkit.org';
-var expectedVersions = ['0.10.2','0.10.1','0.10.0','0.10.0-rc1','0.9.3'];
+var root = 'http://nwjs.io';
+var dlUrl = 'http://dl.nwjs.io/';
+var expectedLegacyVersions = ['0.10.2','0.10.0-rc1','0.9.3'];
 
 test('getLatestVersion', function (t) {
-    t.plan(1);
+    t.plan(3);
 
-    nock(dlUrl).get('/').replyWithFile(200, fixturesVersionsHtml);
-    nock(dlUrl).head('/v0.10.2/node-webkit-v0.10.2-win-ia32.zip')
-        .replyWithFile(200, fixturesVersionsHtml); // needs to reply with *any* content
-    versions.getLatestVersion(dlUrl).then(function(result){
-        t.equal(result, expectedVersions[0]);
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+
+    versions.getLatestVersion('http://dl.nwjs.io/').then(function(result){
+        t.equal(result.version, '0.15.2');
+        t.equal(result.name, 'nwjs');
+        t.deepEqual(result.platforms, {
+            linux32: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-linux-ia32.tar.gz',
+            linux64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-linux-x64.tar.gz',
+            osx64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-osx-x64.zip',
+            win32: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-win-ia32.zip',
+            win64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-win-x64.zip'
+        });
     });
 });
 
 test('getVersions', function (t) {
+    t.plan(5);
+
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    nock(dlUrl).get('/').replyWithFile(200, './test/fixtures/testVersions.html');
+    expectedLegacyVersions.forEach(function(expectedVersion){
+        nock(dlUrl).head('/v' + expectedVersion + '/node-webkit-v' + expectedVersion + '-win-ia32.zip')
+            .replyWithFile(200, './test/fixtures/testVersions.html'); // needs to reply with *any* content
+    });
+
+    versions.getVersions('http://dl.nwjs.io/').then(function(result){
+        var expectedVersions = [
+            {
+                version: '0.15.2',
+                name: 'nwjs',
+                platforms: {
+                    linux32: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-linux-ia32.tar.gz',
+                    linux64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-linux-x64.tar.gz',
+                    osx64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-osx-x64.zip',
+                    win32: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-win-ia32.zip',
+                    win64: 'http://dl.nwjs.io/v0.15.2/nwjs-sdk-v0.15.2-win-x64.zip'
+                },
+                isLegacy: false
+            },
+            {
+                version: '0.13.2',
+                name: 'nwjs',
+                platforms: {
+                    linux32: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-linux-ia32.tar.gz',
+                    osx64: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-osx-x64.zip',
+                    win64: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-win-x64.zip'
+                },
+                isLegacy: false
+            },
+            {
+                version: '0.10.2',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-linux-ia32.tar.gz',
+                    linux64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-linux-x64.tar.gz',
+                    osx32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-osx-ia32.zip',
+                    osx64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-osx-x64.zip',
+                    win32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-win-ia32.zip',
+                    win64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-win-x64.zip'
+                },
+                isLegacy: true
+            },
+            {
+                version: '0.10.0-rc1',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-linux-ia32.tar.gz',
+                    linux64: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-linux-x64.tar.gz',
+                    osx32: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-osx-ia32.zip',
+                    osx64: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-osx-x64.zip',
+                    win32: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-win-ia32.zip',
+                    win64: 'http://dl.nwjs.io/v0.10.0-rc1/node-webkit-v0.10.0-rc1-win-x64.zip'
+                },
+                isLegacy: true
+            },
+            {
+                version: '0.9.3',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-linux-ia32.tar.gz',
+                    linux64: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-linux-x64.tar.gz',
+                    osx32: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-osx-ia32.zip',
+                    osx64: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-osx-x64.zip',
+                    win32: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-win-ia32.zip',
+                    win64: 'http://dl.nwjs.io/v0.9.3/node-webkit-v0.9.3-win-x64.zip'
+                },
+                isLegacy: true
+            }
+        ];
+
+        for(var i = 0; i < expectedVersions.length; i++){
+            t.deepEqual(result[i], expectedVersions[i]);
+        }
+    })
+    .catch(function(err){
+        console.error(err.stack);
+        t.fail(err);
+    });
+});
+
+test('getVersions (custom download URL)', function (t) {
+    t.plan(5);
+
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    nock('http://abc.xyz/').get('/').replyWithFile(200, './test/fixtures/testVersions.html');
+    expectedLegacyVersions.forEach(function(expectedVersion){
+        nock('http://abc.xyz/').head('/v' + expectedVersion + '/node-webkit-v' + expectedVersion + '-win-ia32.zip')
+            .replyWithFile(200, './test/fixtures/testVersions.html'); // needs to reply with *any* content
+    });
+
+    versions.getVersions('http://abc.xyz/').then(function(result){
+        var expectedVersions = [
+            {
+                version: '0.15.2',
+                name: 'nwjs',
+                platforms: {
+                    linux32: 'http://abc.xyz/v0.15.2/nwjs-sdk-v0.15.2-linux-ia32.tar.gz',
+                    linux64: 'http://abc.xyz/v0.15.2/nwjs-sdk-v0.15.2-linux-x64.tar.gz',
+                    osx64: 'http://abc.xyz/v0.15.2/nwjs-sdk-v0.15.2-osx-x64.zip',
+                    win32: 'http://abc.xyz/v0.15.2/nwjs-sdk-v0.15.2-win-ia32.zip',
+                    win64: 'http://abc.xyz/v0.15.2/nwjs-sdk-v0.15.2-win-x64.zip'
+                },
+                isLegacy: false
+            },
+            {
+                version: '0.13.2',
+                name: 'nwjs',
+                platforms: {
+                    linux32: 'http://abc.xyz/v0.13.2/nwjs-sdk-v0.13.2-linux-ia32.tar.gz',
+                    osx64: 'http://abc.xyz/v0.13.2/nwjs-sdk-v0.13.2-osx-x64.zip',
+                    win64: 'http://abc.xyz/v0.13.2/nwjs-sdk-v0.13.2-win-x64.zip'
+                },
+                isLegacy: false
+            },
+            {
+                version: '0.10.2',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-linux-ia32.tar.gz',
+                    linux64: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-linux-x64.tar.gz',
+                    osx32: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-osx-ia32.zip',
+                    osx64: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-osx-x64.zip',
+                    win32: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-win-ia32.zip',
+                    win64: 'http://abc.xyz/v0.10.2/node-webkit-v0.10.2-win-x64.zip'
+                },
+                isLegacy: true
+            },
+            {
+                version: '0.10.0-rc1',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-linux-ia32.tar.gz',
+                    linux64: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-linux-x64.tar.gz',
+                    osx32: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-osx-ia32.zip',
+                    osx64: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-osx-x64.zip',
+                    win32: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-win-ia32.zip',
+                    win64: 'http://abc.xyz/v0.10.0-rc1/node-webkit-v0.10.0-rc1-win-x64.zip'
+                },
+                isLegacy: true
+            },
+            {
+                version: '0.9.3',
+                name: 'node-webkit',
+                platforms: {
+                    linux32: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-linux-ia32.tar.gz',
+                    linux64: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-linux-x64.tar.gz',
+                    osx32: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-osx-ia32.zip',
+                    osx64: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-osx-x64.zip',
+                    win32: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-win-ia32.zip',
+                    win64: 'http://abc.xyz/v0.9.3/node-webkit-v0.9.3-win-x64.zip'
+                },
+                isLegacy: true
+            }
+        ];
+
+        for(var i = 0; i < expectedVersions.length; i++){
+            t.deepEqual(result[i], expectedVersions[i]);
+        }
+    })
+    .catch(function(err){
+        console.error(err.stack);
+        t.fail(err);
+    });
+});
+
+test('getVersion', function (t) {
+    t.plan(3);
+
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    versions.getVersion({
+        desiredVersion: '0.13.2',
+        downloadUrl: 'http://dl.nwjs.io/'
+    }).then(function(result){
+        t.equal(result.version, '0.13.2');
+        t.equal(result.name, 'nwjs');
+        t.deepEqual(result.platforms, {
+            linux32: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-linux-ia32.tar.gz',
+            osx64: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-osx-x64.zip',
+            win64: 'http://dl.nwjs.io/v0.13.2/nwjs-sdk-v0.13.2-win-x64.zip'
+        });
+    });
+});
+
+test('getVersion should fail for non-existent version', function (t) {
     t.plan(1);
 
-    nock(dlUrl).get('/').replyWithFile(200, fixturesVersionsHtml);
-    expectedVersions.forEach(function(expectedVersion){
-        nock(dlUrl).head('/v' + expectedVersion + '/node-webkit-v' + expectedVersion + '-win-ia32.zip')
-            .replyWithFile(200, fixturesVersionsHtml); // needs to reply with *any* content
+    nock(root).get('/versions.json').replyWithFile(200, './test/fixtures/manifest/versions.json');
+    versions.getVersion({
+        desiredVersion:'0.13.3',
+        downloadUrl: 'http://dl.nwjs.io/'
+    }).then(function(){
+        t.fail("Shouldn't go in here")
+    })
+        .catch(function(){
+            t.ok('Should fail');
+        });
+});
+
+test('getVersion (legacy)', function (t) {
+    t.plan(3);
+
+    nock(dlUrl).get('/').replyWithFile(200, './test/fixtures/testVersions.html');
+    nock(dlUrl).head('/v0.10.2/node-webkit-v0.10.2-win-ia32.zip')
+        .replyWithFile(200, './test/fixtures/testVersions.html'); // needs to reply with *any* content
+
+    versions.getVersion({
+        desiredVersion: '0.10.2',
+        downloadUrl:'http://dl.nwjs.io/'
+    }).then(function(result){
+        t.equal(result.version, '0.10.2');
+        t.equal(result.name, 'node-webkit');
+        t.deepEqual(result.platforms, {
+            linux32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-linux-ia32.tar.gz',
+            linux64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-linux-x64.tar.gz',
+            osx32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-osx-ia32.zip',
+            osx64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-osx-x64.zip',
+            win32: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-win-ia32.zip',
+            win64: 'http://dl.nwjs.io/v0.10.2/node-webkit-v0.10.2-win-x64.zip'
+        });
     });
-    versions.getVersions(dlUrl).then(function(result){
-        t.deepEqual(result, expectedVersions);
-    });
 });
 
+test('getVersion (legacy) should fail for non-existent version', function (t) {
+    t.plan(1);
 
-test('getVersionNames', function (t) {
-    t.plan(2);
-
-    var v = '0.8.4';
-    var expected = {
-        linux32: 'v'+v+'/node-webkit-v'+v+'-linux-ia32.tar.gz',
-        linux64: 'v'+v+'/node-webkit-v'+v+'-linux-x64.tar.gz',
-        osx32: 'v'+v+'/node-webkit-v'+v+'-osx-ia32.zip',
-        osx64: 'v'+v+'/node-webkit-v'+v+'-osx-x64.zip',
-        win32: 'v'+v+'/node-webkit-v'+v+'-win-ia32.zip',
-        win64: 'v'+v+'/node-webkit-v'+v+'-win-x64.zip',
-
-    };
-
-    var names = versions.getVersionNames(v);
-    t.equal( names.version, v );
-    t.deepEqual(names.platforms, expected);
-});
-
-test('getVersionNames for 0.12.0-alpha1', function (t) {
-    t.plan(2);
-
-    var v = '0.12.0-alpha1';
-    var expected = {
-        linux32: 'v'+v+'/nwjs-v'+v+'-linux-ia32.tar.gz',
-        linux64: 'v'+v+'/nwjs-v'+v+'-linux-x64.tar.gz',
-        osx32: 'v'+v+'/nwjs-v'+v+'-osx-ia32.zip',
-        osx64: 'v'+v+'/nwjs-v'+v+'-osx-x64.zip',
-        win32: 'v'+v+'/nwjs-v'+v+'-win-ia32.zip',
-        win64: 'v'+v+'/nwjs-v'+v+'-win-x64.zip',
-    };
-
-    var names = versions.getVersionNames(v);
-    t.equal( names.version, v );
-    t.deepEqual(names.platforms, expected);
-});
-
-test('getVersionNames for 0.12.0-alpha2', function (t) {
-    t.plan(2);
-
-    var v = '0.12.0-alpha2';
-    var expected = {
-        linux32: 'v'+v+'/nwjs-v'+v+'-linux-ia32.tar.gz',
-        linux64: 'v'+v+'/nwjs-v'+v+'-linux-x64.tar.gz',
-        osx32: 'v'+v+'/nwjs-v'+v+'-osx-ia32.zip',
-        osx64: 'v'+v+'/nwjs-v'+v+'-osx-x64.zip',
-        win32: 'v'+v+'/nwjs-v'+v+'-win-ia32.zip',
-        win64: 'v'+v+'/nwjs-v'+v+'-win-x64.zip',
-    };
-
-    var names = versions.getVersionNames(v);
-    t.equal( names.version, v );
-    t.deepEqual(names.platforms, expected);
-});
-
-test('getVersionNames for 0.12.0', function (t) {
-    t.plan(2);
-
-    var v = '0.12.0';
-    var expected = {
-        linux32: 'v'+v+'/nwjs-v'+v+'-linux-ia32.tar.gz',
-        linux64: 'v'+v+'/nwjs-v'+v+'-linux-x64.tar.gz',
-        osx32: 'v'+v+'/nwjs-v'+v+'-osx-ia32.zip',
-        osx64: 'v'+v+'/nwjs-v'+v+'-osx-x64.zip',
-        win32: 'v'+v+'/nwjs-v'+v+'-win-ia32.zip',
-        win64: 'v'+v+'/nwjs-v'+v+'-win-x64.zip',
-    };
-
-    var names = versions.getVersionNames(v);
-    t.equal( names.version, v );
-    t.deepEqual(names.platforms, expected);
-});
-
-test('getVersionNames for 1.0.0-alpha1', function (t) {
-    t.plan(2);
-
-    var v = '1.0.0-alpha1';
-    var expected = {
-        linux32: 'v'+v+'/nwjs-v'+v+'-linux-ia32.tar.gz',
-        linux64: 'v'+v+'/nwjs-v'+v+'-linux-x64.tar.gz',
-        osx32: 'v'+v+'/nwjs-v'+v+'-osx-ia32.zip',
-        osx64: 'v'+v+'/nwjs-v'+v+'-osx-x64.zip',
-        win32: 'v'+v+'/nwjs-v'+v+'-win-ia32.zip',
-        win64: 'v'+v+'/nwjs-v'+v+'-win-x64.zip',
-    };
-
-    var names = versions.getVersionNames(v);
-    t.equal( names.version, v );
-    t.deepEqual(names.platforms, expected);
+    nock(dlUrl).get('/').replyWithFile(200, './test/fixtures/testVersions.html');
+    versions.getVersion({
+        desiredVersion: '0.10.1',
+        downloadUrl: 'http://dl.nwjs.io/'
+    }).then(function(){
+        t.fail("shouldn't go in here");
+    })
+        .catch(function(){
+            t.ok('Should fail');
+        });
 });


### PR DESCRIPTION
For #329.

I have only tested this on Mac OS X as I'm abroad right now and I only have my laptop. I'd appreciate it if someone could run our tests and do some manual tests on an example app with varying config.

~~On Mac OS X, there's a problem when building a Mac app with a newer version (e.g. 0.15.2) in that the app name displayed in Finder is `nwjs.app`. I'm not sure why. I've created a StackOverflow question; [App name in Finder not matching app name in Terminal](http://stackoverflow.com/questions/37890440/app-name-in-finder-not-matching-app-name-in-terminal).~~