### PR TITLE
Fix getVersion returning an undefined version

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -158,16 +158,13 @@ module.exports = {
     getVersion: function(args){
         return (isLegacyVersion(args.desiredVersion) ? getLegacyVersions : getVersionsFromManifest)(args.downloadUrl)
             .then(function(versions) {
-                var version = versions.find(function(version){
-                    if(version.version === args.desiredVersion) {
-                        return version;
-                    }
+                var version = versions.findIndex(function(version){
+                    return version.version === args.desiredVersion;
                 });
 
-                if(version){
-                    return version;
-                }
-                throw new Error('Version ' + args.desiredVersion + ' not found.');
+                return version >= 0
+                    ? Promise.resolve(versions[version])
+                    : Promise.reject('Version ' + args.desiredVersion + ' not found.');
             });
     },
     /**


### PR DESCRIPTION
Fixes #343 

This also fixes an issue when defining non-existing versions. Using `0.1000.0` for instance doesn't return a proper error message right now, but instead fails with a "Cannot read property 'linux64' of undefined" error. I'm not sure why [the non-existing versions test](https://github.com/nwjs/nw-builder/blob/0d43c4dfdded6a95f592bfde288a955c1d521de1/test/versions.js#L244) doesn't work correctly...

*Also, setting proper git tags for each release would be great, so they don't have to be referred by their commit id (either for comments here or for targeting a specific version with npm).* 😃 

Thanks!