### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "progress": "~1.1.7",
     "rcedit": "^0.5.0",
     "recursive-readdir-sync": "^1.0.6",
-    "request": "~2.40.0",
+    "request": "~2.74.0",
     "rimraf": "^2.5.2",
     "semver": "^2.3.1",
     "simple-glob": "~0.1.0",


### PR DESCRIPTION
nw-builder currently has a 3 vulnerable dependencies, introducing 4 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/mllrsohn/nw-builder) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade  `simple-glob`, and semver` dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)